### PR TITLE
all: fix strut field order for more less memory

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -25,6 +25,9 @@ type MarshalOptions struct {
 	// Marshalers is a list of type-specific marshalers to use.
 	Marshalers *Marshalers
 
+	// format is custom formatting for the top-level type.
+	format string
+
 	// StringifyNumbers specifies that numeric Go types should be serialized
 	// as a JSON string containing the equivalent JSON number value.
 	//
@@ -38,9 +41,6 @@ type MarshalOptions struct {
 	// JSON object members stored in Go struct fields dedicated to storing
 	// unknown JSON object members.
 	DiscardUnknownMembers bool
-
-	// format is custom formatting for the top-level type.
-	format string
 
 	// TODO: Add other options.
 }
@@ -112,6 +112,9 @@ type UnmarshalOptions struct {
 	// Unmarshalers is a list of type-specific unmarshalers to use.
 	Unmarshalers *Unmarshalers
 
+	// format is custom formatting for the top-level type.
+	format string
+
 	// StringifyNumbers specifies that numeric Go types can be deserialized
 	// from either a JSON number or a JSON string containing a JSON number.
 	StringifyNumbers bool
@@ -127,9 +130,6 @@ type UnmarshalOptions struct {
 	// an unmarshal implementation should return an error that matches
 	// ErrUnknownName according to errors.Is.
 	RejectUnknownNames bool
-
-	// format is custom formatting for the top-level type.
-	format string
 
 	// TODO: Add other options.
 }

--- a/decode.go
+++ b/decode.go
@@ -97,8 +97,8 @@ type DecodeOptions struct {
 // For example, it is probably more common to call ReadToken to obtain a
 // string token for object names.
 type Decoder struct {
-	state
 	decodeBuffer
+	state
 	options DecodeOptions
 }
 
@@ -112,6 +112,12 @@ type Decoder struct {
 // Invariants:
 //	0 ≤ prevStart ≤ prevEnd ≤ len(buf) ≤ cap(buf)
 type decodeBuffer struct {
+	// If rd and bb are both nil, then buf is the entirety of the input.
+	// Otherwise, exactly either rd or bb is non-nil.
+	// If bb is non-nil, then buf aliases the internal buffer of bb.
+	rd io.Reader
+	bb *bytes.Buffer
+
 	buf       []byte
 	prevStart int
 	prevEnd   int
@@ -119,12 +125,6 @@ type decodeBuffer struct {
 	// baseOffset can be added to prevStart and prevEnd to obtain
 	// the absolute offset relative to the start of io.Reader stream.
 	baseOffset int64
-
-	// If rd and bb are both nil, then buf is the entirety of the input.
-	// Otherwise, exactly either rd or bb is non-nil.
-	// If bb is non-nil, then buf aliases the internal buffer of bb.
-	rd io.Reader
-	bb *bytes.Buffer
 }
 
 // NewDecoder constructs a new streaming decoder reading from r.

--- a/encode.go
+++ b/encode.go
@@ -21,32 +21,8 @@ import (
 // which is compliant with both RFC 7493 and RFC 8259.
 type EncodeOptions struct {
 	// TODO: Rename as MarshalOptions?
-	requireKeyedLiterals
 	nonComparable
-
-	// multiline specifies whether to the encoder should emit multiline output.
-	multiline bool
-
-	// omitTopLevelNewline specifies whether to omit the newline
-	// that is typically appended after every top-level JSON value.
-	omitTopLevelNewline bool
-
-	// AllowDuplicateNames specifies that JSON objects may contain
-	// duplicate member names. Disabling the duplicate name check may provide
-	// computational and performance benefits, but breaks compliance with
-	// RFC 7493, section 2.3. The output will still be compliant with RFC 8259,
-	// which leaves the handling of duplicate names as unspecified behavior.
-	AllowDuplicateNames bool
-
-	// AllowInvalidUTF8 specifies that JSON strings may contain invalid UTF-8,
-	// which will be mangled as the Unicode replacement character, U+FFFD.
-	// This causes the encoder to break compliance with
-	// RFC 7493, section 2.1, and RFC 8259, section 8.1.
-	AllowInvalidUTF8 bool
-
-	preserveRawStrings bool
-
-	canonicalizeNumbers bool
+	requireKeyedLiterals
 
 	// EscapeRune reports whether the provided character should be escaped
 	// as a hexadecimal Unicode codepoint (e.g., \ufffd).
@@ -67,6 +43,30 @@ type EncodeOptions struct {
 	// It may only be composed of space or tab characters.
 	// It is ignored if Indent is empty.
 	IndentPrefix string
+
+	// AllowInvalidUTF8 specifies that JSON strings may contain invalid UTF-8,
+	// which will be mangled as the Unicode replacement character, U+FFFD.
+	// This causes the encoder to break compliance with
+	// RFC 7493, section 2.1, and RFC 8259, section 8.1.
+	AllowInvalidUTF8 bool
+
+	preserveRawStrings bool
+
+	canonicalizeNumbers bool
+
+	// multiline specifies whether to the encoder should emit multiline output.
+	multiline bool
+
+	// omitTopLevelNewline specifies whether to omit the newline
+	// that is typically appended after every top-level JSON value.
+	omitTopLevelNewline bool
+
+	// AllowDuplicateNames specifies that JSON objects may contain
+	// duplicate member names. Disabling the duplicate name check may provide
+	// computational and performance benefits, but breaks compliance with
+	// RFC 7493, section 2.3. The output will still be compliant with RFC 8259,
+	// which leaves the handling of duplicate names as unspecified behavior.
+	AllowDuplicateNames bool
 }
 
 // Encoder is a streaming encoder from raw JSON values and tokens.
@@ -99,11 +99,11 @@ type EncodeOptions struct {
 // For example, it is probably more common to call WriteToken with a string
 // for object names.
 type Encoder struct {
-	state
-	encodeBuffer
-	options EncodeOptions
-
 	seenPointers seenPointers // only used when marshaling
+
+	options EncodeOptions
+	encodeBuffer
+	state
 }
 
 // encodeBuffer is a buffer split into 2 segments:
@@ -112,22 +112,23 @@ type Encoder struct {
 //	• buf[len(buf):cap(buf)] // unused portion of the buffer
 //
 type encodeBuffer struct {
-	buf []byte
-
-	// baseOffset can be added to len(buf) to obtain the absolute offset
-	// relative to the start of io.Writer stream.
-	baseOffset int64
-
 	// If wr and bb are both nil, then buf is the entirety of the output.
 	// Otherwise, exactly either wr or bb is non-nil.
 	// If bb is non-nil, then buf aliases the internal buffer of bb.
 	wr io.Writer
 	bb *bytes.Buffer
 
-	// maxValue is the approximate maximum RawValue size passed to WriteValue.
-	maxValue int
+	buf []byte
+
 	// unusedCache is the buffer returned by the UnusedBuffer method.
 	unusedCache []byte
+
+	// baseOffset can be added to len(buf) to obtain the absolute offset
+	// relative to the start of io.Writer stream.
+	baseOffset int64
+
+	// maxValue is the approximate maximum RawValue size passed to WriteValue.
+	maxValue int
 }
 
 // NewEncoder constructs a new streaming encoder writing to w.

--- a/errors.go
+++ b/errors.go
@@ -26,8 +26,8 @@ func (e jsonError) Is(target error) bool {
 }
 
 type ioError struct {
-	action string // either "read" or "write"
 	err    error
+	action string // either "read" or "write"
 }
 
 func (e *ioError) Error() string {
@@ -45,24 +45,26 @@ func (e *ioError) Is(target error) bool {
 //
 // The contents of this error as produced by this package may change over time.
 type SemanticError struct {
-	requireKeyedLiterals
 	nonComparable
+	requireKeyedLiterals
+
+	// GoType is the Go type that could not be handled.
+	GoType reflect.Type
+
+	// Err is the underlying error.
+	Err error // may be nil
 
 	action string // either "marshal" or "unmarshal"
 
-	// ByteOffset indicates that an error occurred after this byte offset.
-	ByteOffset int64
 	// JSONPointer indicates that an error occurred within this JSON value
 	// as indicated using the JSON Pointer notation (see RFC 6901).
 	JSONPointer string
 
-	// JSONKind is the JSON kind that could not be handled.
-	JSONKind Kind // may be zero if unknown
-	// GoType is the Go type that could not be handled.
-	GoType reflect.Type // may be nil if unknown
+	// ByteOffset indicates that an error occurred after this byte offset.
+	ByteOffset int64
 
-	// Err is the underlying error.
-	Err error // may be nil
+	// JSONKind is the JSON kind that could not be handled.
+	JSONKind Kind
 }
 
 func (e *SemanticError) Error() string {
@@ -150,12 +152,12 @@ func (e *SemanticError) Unwrap() error {
 //
 // The contents of this error as produced by this package may change over time.
 type SyntacticError struct {
-	requireKeyedLiterals
 	nonComparable
+	requireKeyedLiterals
+	str string
 
 	// ByteOffset indicates that an error occurred after this byte offset.
 	ByteOffset int64
-	str        string
 }
 
 func (e *SyntacticError) Error() string {

--- a/state.go
+++ b/state.go
@@ -303,14 +303,14 @@ func (nss *objectNamespaceStack) pop() {
 //
 // The zero value is an empty namespace ready for use.
 type objectNamespace struct {
+	// mapNames is a Go map containing every name in the namespace.
+	// Only valid if non-nil.
+	mapNames map[string]struct{}
 	// endOffsets is a list of offsets to the end of each name in buffers.
 	// The length of offsets is the number of names in the namespace.
 	endOffsets []uint
 	// allNames is a back-to-back concatenation of every name in the namespace.
 	allNames []byte
-	// mapNames is a Go map containing every name in the namespace.
-	// Only valid if non-nil.
-	mapNames map[string]struct{}
 }
 
 // reset resets the namespace to be empty.

--- a/tag.go
+++ b/tag.go
@@ -24,20 +24,20 @@ type isZeroer interface {
 var isZeroerType = reflect.TypeOf((*isZeroer)(nil)).Elem()
 
 type structFields struct {
-	flattened       []structField
 	byActualName    map[string]*structField
 	byFoldedName    map[string][]*structField
 	inlinedFallback *structField
+	flattened       []structField
 }
 
 type structField struct {
-	id      int   // unique numeric ID; index into structFields.flattened
-	index   []int // index into a struct according to reflect.Type.FieldByIndex
 	typ     reflect.Type
 	fncs    *arshaler
 	isZero  func(addressableValue) bool
 	isEmpty func(addressableValue) bool
 	fieldOptions
+	index []int // index into a struct according to reflect.Type.FieldByIndex
+	id    int   // unique numeric ID; index into structFields.flattened
 }
 
 func makeStructFields(root reflect.Type) (structFields, *SemanticError) {
@@ -266,15 +266,15 @@ func makeStructFields(root reflect.Type) (structFields, *SemanticError) {
 }
 
 type fieldOptions struct {
-	hasName   bool
 	name      string
-	nocase    bool
+	format    string
+	hasName   bool
 	inline    bool
 	unknown   bool
 	omitzero  bool
 	omitempty bool
 	string    bool
-	format    string
+	nocase    bool
 }
 
 // parseFieldOptions parses the `json` tag in a Go struct field as


### PR DESCRIPTION
Fix strut field order for less memory.

benchmark diff: https://perf.golang.org/search?q=upload:20211030.7.