### PR TITLE
README.md: Link to the Github discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ with the string "WARNING: " near the top of the commit message.
 It is your responsibility to inspect the list of commit changes
 when upgrading the module. Not all breaking changes will lead to build failures.
 
+A [Discussion about including this package in Go as `encoding/json/v2`](https://github.com/golang/go/discussions/63397) has been started on the Go Github project on 2023-10-05. Please provide your feedback there.
+
 ## Goals and objectives
 
 * **Mostly backwards compatible:** If possible, v2 should aim to be _mostly_


### PR DESCRIPTION
It took me a while to find it again. I expected it to be linked from the README but it was not.