### PR TITLE
Use int64 for object or array length

### DIFF
--- a/arshal_test.go
+++ b/arshal_test.go
@@ -3736,7 +3736,10 @@ func TestMarshal(t *testing.T) {
 		want: `[null,{},null,{},null,null,{},{},null,{},null,null,{},"LAST"]`,
 		opts: []Options{
 			WithMarshalers(func() *Marshalers {
-				type P [2]int
+				type P struct {
+					D int
+					N int64
+				}
 				type PV struct {
 					P P
 					V any
@@ -7784,7 +7787,10 @@ func TestUnmarshal(t *testing.T) {
 		}),
 		opts: []Options{
 			WithUnmarshalers(func() *Unmarshalers {
-				type P [2]int
+				type P struct {
+					D int
+					N int64
+				}
 				type PV struct {
 					P P
 					V any

--- a/jsontext/decode.go
+++ b/jsontext/decode.go
@@ -1037,7 +1037,7 @@ func (d *Decoder) StackDepth() int {
 // Each name and value in a JSON object is counted separately,
 // so the effective number of members would be half the length.
 // A complete JSON object must have an even length.
-func (d *Decoder) StackIndex(i int) (Kind, int) {
+func (d *Decoder) StackIndex(i int) (Kind, int64) {
 	// NOTE: Keep in sync with Encoder.StackIndex.
 	switch s := d.s.Tokens.index(i); {
 	case i > 0 && s.isObject():

--- a/jsontext/encode.go
+++ b/jsontext/encode.go
@@ -896,7 +896,7 @@ func (e *Encoder) StackDepth() int {
 // Each name and value in a JSON object is counted separately,
 // so the effective number of members would be half the length.
 // A complete JSON object must have an even length.
-func (e *Encoder) StackIndex(i int) (Kind, int) {
+func (e *Encoder) StackIndex(i int) (Kind, int64) {
 	// NOTE: Keep in sync with Decoder.StackIndex.
 	switch s := e.s.Tokens.index(i); {
 	case i > 0 && s.isObject():

--- a/jsontext/state.go
+++ b/jsontext/state.go
@@ -133,7 +133,7 @@ func (m *stateMachine) index(i int) *stateEntry {
 
 // DepthLength reports the current nested depth and
 // the length of the last JSON object or array.
-func (m stateMachine) DepthLength() (int, int) {
+func (m stateMachine) DepthLength() (int, int64) {
 	return m.Depth(), m.Last.Length()
 }
 
@@ -342,8 +342,8 @@ const (
 
 // Length reports the number of elements in the JSON object or array.
 // Each name and value in an object entry is treated as a separate element.
-func (e stateEntry) Length() int {
-	return int(e & stateCountMask)
+func (e stateEntry) Length() int64 {
+	return int64(e & stateCountMask)
 }
 
 // isObject reports whether this is a JSON object.

--- a/jsontext/state_test.go
+++ b/jsontext/state_test.go
@@ -20,7 +20,7 @@ func TestStateMachine(t *testing.T) {
 	type operation any
 	type (
 		// stackLengths checks the results of stateEntry.length accessors.
-		stackLengths []int
+		stackLengths []int64
 
 		// appendTokens is sequence of token kinds to append where
 		// none of them are expected to fail.
@@ -156,12 +156,12 @@ func TestStateMachine(t *testing.T) {
 			for _, op := range ops {
 				switch op := op.(type) {
 				case stackLengths:
-					var got []int
+					var got []int64
 					for i := 0; i < state.Depth(); i++ {
 						e := state.index(i)
 						got = append(got, e.Length())
 					}
-					want := []int(op)
+					want := []int64(op)
 					if !reflect.DeepEqual(got, want) {
 						t.Fatalf("%s: stack lengths mismatch:\ngot  %v\nwant %v", sequence, got, want)
 					}


### PR DESCRIPTION
WARNING: This commit includes breaking changes.

When processing JSON as a stream, it is conceivable that the total number of elements in a JSON object or array exceeds a 32-bit integer.

Switch from int to int64 for a similar reason as why io.Copy returns int64 instead of int.

Note that the depth still uses an int because the stack must be representable in memory, which is limited to the native integer width of the platform. This is similar to how io.Reader.Read returns an int because the length of a []byte cannot possibly be larger than the largest int.