### PR TITLE
Reject JSON numbers with StringifyNumbers when unmarshaling

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -409,6 +409,9 @@ func makeIntArshaler(t reflect.Type) *arshaler {
 			val = jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 			fallthrough
 		case '0':
+			if uo.Flags.Get(jsonflags.StringifyNumbers) && k == '0' {
+				break
+			}
 			var negOffset int
 			neg := len(val) > 0 && val[0] == '-'
 			if neg {
@@ -486,6 +489,9 @@ func makeUintArshaler(t reflect.Type) *arshaler {
 			val = jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 			fallthrough
 		case '0':
+			if uo.Flags.Get(jsonflags.StringifyNumbers) && k == '0' {
+				break
+			}
 			n, ok := jsonwire.ParseUint(val)
 			maxUint := uint64(1) << bits
 			overflow := n > maxUint-1
@@ -590,6 +596,9 @@ func makeFloatArshaler(t reflect.Type) *arshaler {
 			}
 			fallthrough
 		case '0':
+			if uo.Flags.Get(jsonflags.StringifyNumbers) && k == '0' {
+				break
+			}
 			fv, ok := jsonwire.ParseFloat(val, bits)
 			if !ok && uo.Flags.Get(jsonflags.RejectFloatOverflow) {
 				return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t, Err: strconv.ErrRange}

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -4686,6 +4686,13 @@ func TestUnmarshal(t *testing.T) {
 		inVal: new(int),
 		want:  addr(int(-6464)),
 	}, {
+		name:    jsontest.Name("Ints/Stringified/Invalid"),
+		opts:    []Options{StringifyNumbers(true)},
+		inBuf:   `-6464`,
+		inVal:   new(int),
+		want:    new(int),
+		wantErr: &SemanticError{action: "unmarshal", JSONKind: '0', GoType: intType},
+	}, {
 		name:    jsontest.Name("Ints/Stringified/LeadingZero"),
 		opts:    []Options{StringifyNumbers(true)},
 		inBuf:   `"00"`,
@@ -4870,6 +4877,13 @@ func TestUnmarshal(t *testing.T) {
 		inVal: new(uint),
 		want:  addr(uint(6464)),
 	}, {
+		name:    jsontest.Name("Uints/Stringified/Invalid"),
+		opts:    []Options{StringifyNumbers(true)},
+		inBuf:   `6464`,
+		inVal:   new(uint),
+		want:    new(uint),
+		wantErr: &SemanticError{action: "unmarshal", JSONKind: '0', GoType: uintType},
+	}, {
 		name:    jsontest.Name("Uints/Stringified/LeadingZero"),
 		opts:    []Options{StringifyNumbers(true)},
 		inBuf:   `"00"`,
@@ -5042,6 +5056,13 @@ func TestUnmarshal(t *testing.T) {
 		inBuf: `"64.64"`,
 		inVal: new(float64),
 		want:  addr(float64(64.64)),
+	}, {
+		name:    jsontest.Name("Floats/Stringified/Invalid"),
+		opts:    []Options{StringifyNumbers(true)},
+		inBuf:   `64.64`,
+		inVal:   new(float64),
+		want:    new(float64),
+		wantErr: &SemanticError{action: "unmarshal", JSONKind: '0', GoType: float64Type},
 	}, {
 		name:  jsontest.Name("Floats/Escaped"),
 		opts:  []Options{StringifyNumbers(true)},
@@ -5488,33 +5509,33 @@ func TestUnmarshal(t *testing.T) {
 	"Bool": true,
 	"String": "hello",
 	"Bytes": "AQID",
-	"Int": -64,
-	"Uint": 64,
-	"Float": 3.14159,
+	"Int": "-64",
+	"Uint": "64",
+	"Float": "3.14159",
 	"Map": {"key": "value"},
 	"StructScalars": {
 		"Bool": true,
 		"String": "hello",
 		"Bytes": "AQID",
-		"Int": -64,
-		"Uint": 64,
-		"Float": 3.14159
+		"Int": "-64",
+		"Uint": "64",
+		"Float": "3.14159"
 	},
 	"StructMaps": {
 		"MapBool": {"": true},
 		"MapString": {"": "hello"},
 		"MapBytes": {"": "AQID"},
-		"MapInt": {"": -64},
-		"MapUint": {"": 64},
-		"MapFloat": {"": 3.14159}
+		"MapInt": {"": "-64"},
+		"MapUint": {"": "64"},
+		"MapFloat": {"": "3.14159"}
 	},
 	"StructSlices": {
 		"SliceBool": [true],
 		"SliceString": ["hello"],
 		"SliceBytes": ["AQID"],
-		"SliceInt": [-64],
-		"SliceUint": [64],
-		"SliceFloat": [3.14159]
+		"SliceInt": ["-64"],
+		"SliceUint": ["64"],
+		"SliceFloat": ["3.14159"]
 	},
 	"Slice": ["fizz","buzz"],
 	"Array": ["goodbye"],
@@ -6318,7 +6339,7 @@ func TestUnmarshal(t *testing.T) {
 	}, {
 		name:  jsontest.Name("Structs/InlinedFallback/MapStringInt/StringifiedNumbers"),
 		opts:  []Options{StringifyNumbers(true)},
-		inBuf: `{"zero": 0, "one": "1", "two": 2}`,
+		inBuf: `{"zero": "0", "one": "1", "two": "2"}`,
 		inVal: new(structInlineMapStringInt),
 		want: addr(structInlineMapStringInt{
 			X: map[string]int{"zero": 0, "one": 1, "two": 2},


### PR DESCRIPTION
WARNING: This commit includes breaking changes.

Previously, if StringifyNumbers was specified,
we would permit unmarshaling of a JSON number into a Go number. However, this is not how the v1 equivalent functionality operated. In v1, once the `string` tag option was specified, it would only unmarshal a JSON string containing a JSON number, but would reject a JSON number.

It may be reasonable to provide a separate option that allows the more flexible unmarshal behavior that this commit breaks, but that can be a future change. For now, we are working towards implementing v1 entirely in terms of v2.