### PR TITLE
Implement support for OmitZeroStructFields

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -936,7 +936,8 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 
 			// OmitZero skips the field if the Go value is zero,
 			// which we can determine up front without calling the marshaler.
-			if f.omitzero && ((f.isZero == nil && v.IsZero()) || (f.isZero != nil && f.isZero(v))) {
+			if (f.omitzero || mo.Flags.Get(jsonflags.OmitZeroStructFields)) &&
+				((f.isZero == nil && v.IsZero()) || (f.isZero != nil && f.isZero(v))) {
 				continue
 			}
 

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -1397,6 +1397,11 @@ func TestMarshal(t *testing.T) {
 		in:   structOmitZeroAll{},
 		want: `{}`,
 	}, {
+		name: jsontest.Name("Structs/OmitZeroOption/Zero"),
+		opts: []Options{OmitZeroStructFields(true)},
+		in:   structAll{},
+		want: `{}`,
+	}, {
 		name: jsontest.Name("Structs/OmitZero/NonZero"),
 		opts: []Options{jsontext.Multiline(true)},
 		in: structOmitZeroAll{
@@ -1447,6 +1452,45 @@ func TestMarshal(t *testing.T) {
 		"SliceUint": [],
 		"SliceFloat": []
 	},
+	"Slice": [],
+	"Array": [
+		" "
+	],
+	"Pointer": {},
+	"Interface": null
+}`,
+	}, {
+		name: jsontest.Name("Structs/OmitZeroOption/NonZero"),
+		opts: []Options{OmitZeroStructFields(true), jsontext.Multiline(true)},
+		in: structAll{
+			Bool:          true,
+			String:        " ",
+			Bytes:         []byte{},
+			Int:           1,
+			Uint:          1,
+			Float:         math.SmallestNonzeroFloat64,
+			Map:           map[string]string{},
+			StructScalars: structScalars{unexported: true},
+			StructSlices:  structSlices{Ignored: true},
+			StructMaps:    structMaps{MapBool: map[string]bool{}},
+			Slice:         []string{},
+			Array:         [1]string{" "},
+			Pointer:       new(structAll),
+			Interface:     (*structAll)(nil),
+		},
+		want: `{
+	"Bool": true,
+	"String": " ",
+	"Bytes": "",
+	"Int": 1,
+	"Uint": 1,
+	"Float": 5e-324,
+	"Map": {},
+	"StructScalars": {},
+	"StructMaps": {
+		"MapBool": {}
+	},
+	"StructSlices": {},
 	"Slice": [],
 	"Array": [
 		" "

--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -106,6 +106,7 @@ const (
 	Deterministic             // marshal only
 	FormatNilMapAsNull        // marshal only
 	FormatNilSliceAsNull      // marshal only
+	OmitZeroStructFields      // marshal only
 	MatchCaseInsensitiveNames // marshal or unmarshal
 	DiscardUnknownMembers     // marshal only
 	RejectUnknownMembers      // unmarshal only

--- a/options.go
+++ b/options.go
@@ -167,6 +167,22 @@ func FormatNilMapAsNull(v bool) Options {
 	}
 }
 
+// OmitZeroStructFields specifies that a Go struct should marshal in such a way
+// that all struct fields that are zero are omitted from the marshaled output
+// if the value is zero as determined by the "IsZero() bool" method if present,
+// otherwise based on whether the field is the zero Go value.
+// This is semantically equivalent to specifying the `omitzero` tag option
+// on every field in a Go struct.
+//
+// This only affects marshaling and is ignored when unmarshaling.
+func OmitZeroStructFields(v bool) Options {
+	if v {
+		return jsonflags.OmitZeroStructFields | 1
+	} else {
+		return jsonflags.OmitZeroStructFields | 0
+	}
+}
+
 // MatchCaseInsensitiveNames specifies that JSON object members are matched
 // against Go struct fields using a case-insensitive match of the name.
 // Go struct fields explicitly marked with `strictcase` or `nocase`


### PR DESCRIPTION
By default, Marshal serializes Go structs with all fields even if each field is the zero Go value.
This can lead to verbose output emitting fields for which it is often indistinguishable from the zero value of the field itself.

The caller-specified OmitZeroStructFields is equivalent to specifying the omitzero tag option on every Go struct field. Static analysis of Go code used with JSON indicates that about 50% of all struct fields have `omitempty` specified. While `omitempty` is not the same as `omitzero`, it is probably safer to provide a caller-scoped OmitZeroStructFields option since doing so is more likely to produce output that is semantically equivalent to if the option was not specified at all.

The exceptions to the above is if the field value contains a -0.0 or if it implements IsZero that treats certain values other than the zero Go value as "zero".