### PR TITLE
Remove redundant check for kind

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -409,7 +409,7 @@ func makeIntArshaler(t reflect.Type) *arshaler {
 			val = jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 			fallthrough
 		case '0':
-			if uo.Flags.Get(jsonflags.StringifyNumbers) && k == '0' {
+			if uo.Flags.Get(jsonflags.StringifyNumbers) {
 				break
 			}
 			var negOffset int
@@ -489,7 +489,7 @@ func makeUintArshaler(t reflect.Type) *arshaler {
 			val = jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 			fallthrough
 		case '0':
-			if uo.Flags.Get(jsonflags.StringifyNumbers) && k == '0' {
+			if uo.Flags.Get(jsonflags.StringifyNumbers) {
 				break
 			}
 			n, ok := jsonwire.ParseUint(val)
@@ -596,7 +596,7 @@ func makeFloatArshaler(t reflect.Type) *arshaler {
 			}
 			fallthrough
 		case '0':
-			if uo.Flags.Get(jsonflags.StringifyNumbers) && k == '0' {
+			if uo.Flags.Get(jsonflags.StringifyNumbers) {
 				break
 			}
 			fv, ok := jsonwire.ParseFloat(val, bits)


### PR DESCRIPTION
In three instances, there is a check if `k == '0'` in a switch case for `k := val.Kind()` where `case '0'`, so those checks are redundant and I have removed them.