### PR TITLE
Add JSONPointer to SyntacticError

### DIFF
--- a/arshal_any.go
+++ b/arshal_any.go
@@ -177,7 +177,7 @@ func unmarshalObjectAny(dec *jsontext.Decoder, uo *jsonopts.Struct) (map[string]
 			// Manually check for duplicate names.
 			if _, ok := obj[name]; ok {
 				name := xd.PreviousBuffer()
-				err := export.NewDuplicateNameError(name, dec.InputOffset()-len64(name))
+				err := newDuplicateNameError(dec.StackPointer(), nil, dec.InputOffset()-len64(name))
 				return obj, err
 			}
 

--- a/arshal_default.go
+++ b/arshal_default.go
@@ -890,7 +890,7 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 					if !xd.Flags.Get(jsonflags.AllowDuplicateNames) && (!seen.IsValid() || seen.MapIndex(k.Value).IsValid()) {
 						// TODO: Unread the object name.
 						name := xd.PreviousBuffer()
-						err := export.NewDuplicateNameError(name, dec.InputOffset()-len64(name))
+						err := newDuplicateNameError(dec.StackPointer(), nil, dec.InputOffset()-len64(name))
 						return err
 					}
 					v.Set(v2)
@@ -1160,7 +1160,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 						}
 						if !xd.Flags.Get(jsonflags.AllowDuplicateNames) && !xd.Namespaces.Last().InsertUnquoted(name) {
 							// TODO: Unread the object name.
-							err := export.NewDuplicateNameError(val, dec.InputOffset()-len64(val))
+							err := newDuplicateNameError(dec.StackPointer(), nil, dec.InputOffset()-len64(val))
 							return err
 						}
 
@@ -1180,7 +1180,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 				}
 				if !xd.Flags.Get(jsonflags.AllowDuplicateNames) && !seenIdxs.insert(uint(f.id)) {
 					// TODO: Unread the object name.
-					err := export.NewDuplicateNameError(val, dec.InputOffset()-len64(val))
+					err := newDuplicateNameError(dec.StackPointer(), nil, dec.InputOffset()-len64(val))
 					return err
 				}
 

--- a/arshal_inlined.go
+++ b/arshal_inlined.go
@@ -78,7 +78,7 @@ func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *j
 			if insertUnquotedName != nil {
 				name := jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 				if !insertUnquotedName(name) {
-					return export.NewDuplicateNameError(val, 0)
+					return newDuplicateNameError(enc.StackPointer().Parent(), val, enc.OutputOffset())
 				}
 			}
 			if err := enc.WriteValue(val); err != nil {
@@ -119,7 +119,7 @@ func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *j
 				isVerbatim := bytes.IndexByte(b, '\\') < 0
 				name := jsonwire.UnquoteMayCopy(b, isVerbatim)
 				if !insertUnquotedName(name) {
-					return export.NewDuplicateNameError(b, 0)
+					return newDuplicateNameError(enc.StackPointer().Parent(), b, enc.OutputOffset())
 				}
 			}
 			return enc.WriteValue(b)

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-json-experiment/json/internal/jsonwire"
 	"github.com/go-json-experiment/json/jsontext"
 )
 
@@ -114,4 +115,16 @@ func (e *SemanticError) Error() string {
 }
 func (e *SemanticError) Unwrap() error {
 	return e.Err
+}
+
+func newDuplicateNameError(ptr jsontext.Pointer, quotedName []byte, offset int64) error {
+	if quotedName != nil {
+		name, _ := jsonwire.AppendUnquote(nil, quotedName)
+		ptr = ptr.AppendToken(string(name))
+	}
+	return &jsontext.SyntacticError{
+		ByteOffset:  offset,
+		JSONPointer: ptr,
+		Err:         jsontext.ErrDuplicateName,
+	}
 }

--- a/internal/jsonwire/wire.go
+++ b/internal/jsonwire/wire.go
@@ -141,16 +141,11 @@ func truncateMaxUTF8[Bytes ~[]byte | ~string](b Bytes) Bytes {
 	return b
 }
 
-// NewError and ErrInvalidUTF8 are injected by the "jsontext" package,
-// so that these error types use the jsontext.SyntacticError type.
-var (
-	NewError       = errors.New
-	ErrInvalidUTF8 = errors.New("invalid UTF-8 within string")
-)
+var ErrInvalidUTF8 = errors.New("invalid UTF-8")
 
 func NewInvalidCharacterError[Bytes ~[]byte | ~string](prefix Bytes, where string) error {
 	what := QuoteRune(prefix)
-	return NewError("invalid character " + what + " " + where)
+	return errors.New("invalid character " + what + " " + where)
 }
 
 func NewInvalidEscapeSequenceError[Bytes ~[]byte | ~string](what Bytes) error {
@@ -162,8 +157,8 @@ func NewInvalidEscapeSequenceError[Bytes ~[]byte | ~string](what Bytes) error {
 		return r == '`' || r == utf8.RuneError || unicode.IsSpace(r) || !unicode.IsPrint(r)
 	}) >= 0
 	if needEscape {
-		return NewError("invalid " + label + " " + strconv.Quote(string(what)) + " within string")
+		return errors.New("invalid " + label + " " + strconv.Quote(string(what)) + " within string")
 	} else {
-		return NewError("invalid " + label + " `" + string(what) + "` within string")
+		return errors.New("invalid " + label + " `" + string(what) + "` within string")
 	}
 }

--- a/jsontext/decode.go
+++ b/jsontext/decode.go
@@ -255,16 +255,7 @@ func (d *decodeBuffer) needMore(pos int) bool {
 	return pos == len(d.buf)
 }
 
-// injectSyntacticErrorWithPosition wraps a SyntacticError with the position,
-// otherwise it returns the error as is.
-// It takes a position relative to the start of the start of d.buf.
-func (d *decodeBuffer) injectSyntacticErrorWithPosition(err error, pos int) error {
-	if serr, ok := err.(*SyntacticError); ok {
-		return serr.withOffset(d.baseOffset + int64(pos))
-	}
-	return err
-}
-
+func (d *decodeBuffer) offsetAt(pos int) int64     { return d.baseOffset + int64(pos) }
 func (d *decodeBuffer) previousOffsetStart() int64 { return d.baseOffset + int64(d.prevStart) }
 func (d *decodeBuffer) previousOffsetEnd() int64   { return d.baseOffset + int64(d.prevEnd) }
 func (d *decodeBuffer) PreviousBuffer() []byte     { return d.buf[d.prevStart:d.prevEnd] }
@@ -292,7 +283,7 @@ func (d *decoderState) PeekKind() Kind {
 			if err == io.ErrUnexpectedEOF && d.Tokens.Depth() == 1 {
 				err = io.EOF // EOF possibly if no Tokens present after top-level value
 			}
-			d.peekPos, d.peekErr = -1, err
+			d.peekPos, d.peekErr = -1, wrapSyntacticError(d, err, pos, 0)
 			return invalidKind
 		}
 	}
@@ -305,6 +296,7 @@ func (d *decoderState) PeekKind() Kind {
 		pos += jsonwire.ConsumeWhitespace(d.buf[pos:])
 		if d.needMore(pos) {
 			if pos, err = d.consumeWhitespace(pos); err != nil {
+				err = wrapSyntacticError(d, err, pos, 0)
 				d.peekPos, d.peekErr = -1, d.checkDelimBeforeIOError(delim, err)
 				return invalidKind
 			}
@@ -344,7 +336,7 @@ func (d *decoderState) checkDelim(delim byte, next Kind) error {
 	pos := d.prevEnd // restore position to right after leading whitespace
 	pos += jsonwire.ConsumeWhitespace(d.buf[pos:])
 	err := d.Tokens.checkDelim(delim, next)
-	return d.injectSyntacticErrorWithPosition(err, pos)
+	return wrapSyntacticError(d, err, pos, 0)
 }
 
 // SkipValue is semantically equivalent to calling [Decoder.ReadValue] and discarding
@@ -408,7 +400,7 @@ func (d *decoderState) ReadToken() (Token, error) {
 				if err == io.ErrUnexpectedEOF && d.Tokens.Depth() == 1 {
 					err = io.EOF // EOF possibly if no Tokens present after top-level value
 				}
-				return Token{}, err
+				return Token{}, wrapSyntacticError(d, err, pos, 0)
 			}
 		}
 
@@ -420,6 +412,7 @@ func (d *decoderState) ReadToken() (Token, error) {
 			pos += jsonwire.ConsumeWhitespace(d.buf[pos:])
 			if d.needMore(pos) {
 				if pos, err = d.consumeWhitespace(pos); err != nil {
+					err = wrapSyntacticError(d, err, pos, 0)
 					return Token{}, d.checkDelimBeforeIOError(delim, err)
 				}
 			}
@@ -437,13 +430,13 @@ func (d *decoderState) ReadToken() (Token, error) {
 		if jsonwire.ConsumeNull(d.buf[pos:]) == 0 {
 			pos, err = d.consumeLiteral(pos, "null")
 			if err != nil {
-				return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+				return Token{}, wrapSyntacticError(d, err, pos, +1)
 			}
 		} else {
 			pos += len("null")
 		}
 		if err = d.Tokens.appendLiteral(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos-len("null")) // report position at start of literal
+			return Token{}, wrapSyntacticError(d, err, pos-len("null"), +1) // report position at start of literal
 		}
 		d.prevStart, d.prevEnd = pos, pos
 		return Null, nil
@@ -452,13 +445,13 @@ func (d *decoderState) ReadToken() (Token, error) {
 		if jsonwire.ConsumeFalse(d.buf[pos:]) == 0 {
 			pos, err = d.consumeLiteral(pos, "false")
 			if err != nil {
-				return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+				return Token{}, wrapSyntacticError(d, err, pos, +1)
 			}
 		} else {
 			pos += len("false")
 		}
 		if err = d.Tokens.appendLiteral(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos-len("false")) // report position at start of literal
+			return Token{}, wrapSyntacticError(d, err, pos-len("false"), +1) // report position at start of literal
 		}
 		d.prevStart, d.prevEnd = pos, pos
 		return False, nil
@@ -467,13 +460,13 @@ func (d *decoderState) ReadToken() (Token, error) {
 		if jsonwire.ConsumeTrue(d.buf[pos:]) == 0 {
 			pos, err = d.consumeLiteral(pos, "true")
 			if err != nil {
-				return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+				return Token{}, wrapSyntacticError(d, err, pos, +1)
 			}
 		} else {
 			pos += len("true")
 		}
 		if err = d.Tokens.appendLiteral(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos-len("true")) // report position at start of literal
+			return Token{}, wrapSyntacticError(d, err, pos-len("true"), +1) // report position at start of literal
 		}
 		d.prevStart, d.prevEnd = pos, pos
 		return True, nil
@@ -486,7 +479,7 @@ func (d *decoderState) ReadToken() (Token, error) {
 			newAbsPos := d.baseOffset + int64(pos)
 			n = int(newAbsPos - oldAbsPos)
 			if err != nil {
-				return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+				return Token{}, wrapSyntacticError(d, err, pos, +1)
 			}
 		} else {
 			pos += n
@@ -494,17 +487,17 @@ func (d *decoderState) ReadToken() (Token, error) {
 		if d.Tokens.Last.NeedObjectName() {
 			if !d.Flags.Get(jsonflags.AllowDuplicateNames) {
 				if !d.Tokens.Last.isValidNamespace() {
-					return Token{}, errInvalidNamespace
+					return Token{}, wrapSyntacticError(d, errInvalidNamespace, pos-n, +1)
 				}
 				if d.Tokens.Last.isActiveNamespace() && !d.Namespaces.Last().insertQuoted(d.buf[pos-n:pos], flags.IsVerbatim()) {
-					err = newDuplicateNameError(d.buf[pos-n : pos])
-					return Token{}, d.injectSyntacticErrorWithPosition(err, pos-n) // report position at start of string
+					err = wrapWithObjectName(ErrDuplicateName, d.buf[pos-n:pos])
+					return Token{}, wrapSyntacticError(d, err, pos-n, +1) // report position at start of string
 				}
 			}
 			d.Names.ReplaceLastQuotedOffset(pos - n) // only replace if insertQuoted succeeds
 		}
 		if err = d.Tokens.appendString(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos-n) // report position at start of string
+			return Token{}, wrapSyntacticError(d, err, pos-n, +1) // report position at start of string
 		}
 		d.prevStart, d.prevEnd = pos-n, pos
 		return Token{raw: &d.decodeBuffer, num: uint64(d.previousOffsetStart())}, nil
@@ -518,20 +511,20 @@ func (d *decoderState) ReadToken() (Token, error) {
 			newAbsPos := d.baseOffset + int64(pos)
 			n = int(newAbsPos - oldAbsPos)
 			if err != nil {
-				return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+				return Token{}, wrapSyntacticError(d, err, pos, +1)
 			}
 		} else {
 			pos += n
 		}
 		if err = d.Tokens.appendNumber(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos-n) // report position at start of number
+			return Token{}, wrapSyntacticError(d, err, pos-n, +1) // report position at start of number
 		}
 		d.prevStart, d.prevEnd = pos-n, pos
 		return Token{raw: &d.decodeBuffer, num: uint64(d.previousOffsetStart())}, nil
 
 	case '{':
 		if err = d.Tokens.pushObject(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+			return Token{}, wrapSyntacticError(d, err, pos, +1)
 		}
 		d.Names.push()
 		if !d.Flags.Get(jsonflags.AllowDuplicateNames) {
@@ -543,7 +536,7 @@ func (d *decoderState) ReadToken() (Token, error) {
 
 	case '}':
 		if err = d.Tokens.popObject(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+			return Token{}, wrapSyntacticError(d, err, pos, +1)
 		}
 		d.Names.pop()
 		if !d.Flags.Get(jsonflags.AllowDuplicateNames) {
@@ -555,7 +548,7 @@ func (d *decoderState) ReadToken() (Token, error) {
 
 	case '[':
 		if err = d.Tokens.pushArray(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+			return Token{}, wrapSyntacticError(d, err, pos, +1)
 		}
 		pos += 1
 		d.prevStart, d.prevEnd = pos, pos
@@ -563,15 +556,15 @@ func (d *decoderState) ReadToken() (Token, error) {
 
 	case ']':
 		if err = d.Tokens.popArray(); err != nil {
-			return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+			return Token{}, wrapSyntacticError(d, err, pos, +1)
 		}
 		pos += 1
 		d.prevStart, d.prevEnd = pos, pos
 		return ArrayEnd, nil
 
 	default:
-		err = newInvalidCharacterError(d.buf[pos:], "at start of token")
-		return Token{}, d.injectSyntacticErrorWithPosition(err, pos)
+		err = jsonwire.NewInvalidCharacterError(d.buf[pos:], "at start of token")
+		return Token{}, wrapSyntacticError(d, err, pos, +1)
 	}
 }
 
@@ -614,7 +607,7 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 				if err == io.ErrUnexpectedEOF && d.Tokens.Depth() == 1 {
 					err = io.EOF // EOF possibly if no Tokens present after top-level value
 				}
-				return nil, err
+				return nil, wrapSyntacticError(d, err, pos, 0)
 			}
 		}
 
@@ -626,6 +619,7 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 			pos += jsonwire.ConsumeWhitespace(d.buf[pos:])
 			if d.needMore(pos) {
 				if pos, err = d.consumeWhitespace(pos); err != nil {
+					err = wrapSyntacticError(d, err, pos, 0)
 					return nil, d.checkDelimBeforeIOError(delim, err)
 				}
 			}
@@ -642,7 +636,7 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 	newAbsPos := d.baseOffset + int64(pos)
 	n := int(newAbsPos - oldAbsPos)
 	if err != nil {
-		return nil, d.injectSyntacticErrorWithPosition(err, pos)
+		return nil, wrapSyntacticError(d, err, pos, +1)
 	}
 	switch next {
 	case 'n', 't', 'f':
@@ -655,7 +649,7 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 					break
 				}
 				if d.Tokens.Last.isActiveNamespace() && !d.Namespaces.Last().insertQuoted(d.buf[pos-n:pos], flags.IsVerbatim()) {
-					err = newDuplicateNameError(d.buf[pos-n : pos])
+					err = wrapWithObjectName(ErrDuplicateName, d.buf[pos-n:pos])
 					break
 				}
 			}
@@ -680,7 +674,7 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 		}
 	}
 	if err != nil {
-		return nil, d.injectSyntacticErrorWithPosition(err, pos-n) // report position at start of value
+		return nil, wrapSyntacticError(d, err, pos-n, +1) // report position at start of value
 	}
 	d.prevEnd = pos
 	d.prevStart = pos - n
@@ -691,8 +685,8 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 func (d *decoderState) CheckEOF() error {
 	switch pos, err := d.consumeWhitespace(d.prevEnd); err {
 	case nil:
-		err := newInvalidCharacterError(d.buf[pos:], "after top-level value")
-		return d.injectSyntacticErrorWithPosition(err, pos)
+		err := jsonwire.NewInvalidCharacterError(d.buf[pos:], "after top-level value")
+		return wrapSyntacticError(d, err, pos, 0)
 	case io.ErrUnexpectedEOF:
 		return nil
 	default:
@@ -767,14 +761,14 @@ func (d *decoderState) consumeValue(flags *jsonwire.ValueFlags, pos, depth int) 
 		case '[':
 			return d.consumeArray(flags, pos, depth)
 		default:
-			return pos, newInvalidCharacterError(d.buf[pos:], "at start of value")
+			return pos, jsonwire.NewInvalidCharacterError(d.buf[pos:], "at start of value")
 		}
 		if err == io.ErrUnexpectedEOF {
 			absPos := d.baseOffset + int64(pos)
 			err = d.fetch() // will mutate d.buf and invalidate pos
 			pos = int(absPos - d.baseOffset)
 			if err != nil {
-				return pos, err
+				return pos + n, err
 			}
 			continue
 		}
@@ -792,7 +786,7 @@ func (d *decoderState) consumeLiteral(pos int, lit string) (newPos int, err erro
 			err = d.fetch() // will mutate d.buf and invalidate pos
 			pos = int(absPos - d.baseOffset)
 			if err != nil {
-				return pos, err
+				return pos + n, err
 			}
 			continue
 		}
@@ -811,7 +805,7 @@ func (d *decoderState) consumeString(flags *jsonwire.ValueFlags, pos int) (newPo
 			err = d.fetch() // will mutate d.buf and invalidate pos
 			pos = int(absPos - d.baseOffset)
 			if err != nil {
-				return pos, err
+				return pos + n, err
 			}
 			continue
 		}
@@ -898,19 +892,21 @@ func (d *decoderState) consumeObject(flags *jsonwire.ValueFlags, pos, depth int)
 		} else {
 			pos += n
 		}
-		if !d.Flags.Get(jsonflags.AllowDuplicateNames) && !names.insertQuoted(d.buf[pos-n:pos], flags2.IsVerbatim()) {
-			return pos - n, newDuplicateNameError(d.buf[pos-n : pos])
+		quotedName := d.buf[pos-n : pos]
+		if !d.Flags.Get(jsonflags.AllowDuplicateNames) && !names.insertQuoted(quotedName, flags2.IsVerbatim()) {
+			return pos - n, wrapWithObjectName(ErrDuplicateName, quotedName)
 		}
 
 		// Handle after name.
 		pos += jsonwire.ConsumeWhitespace(d.buf[pos:])
 		if d.needMore(pos) {
 			if pos, err = d.consumeWhitespace(pos); err != nil {
-				return pos, err
+				return pos, wrapWithObjectName(err, quotedName)
 			}
 		}
 		if d.buf[pos] != ':' {
-			return pos, newInvalidCharacterError(d.buf[pos:], "after object name (expecting ':')")
+			err := jsonwire.NewInvalidCharacterError(d.buf[pos:], "after object name (expecting ':')")
+			return pos, wrapWithObjectName(err, quotedName)
 		}
 		pos++
 
@@ -918,12 +914,12 @@ func (d *decoderState) consumeObject(flags *jsonwire.ValueFlags, pos, depth int)
 		pos += jsonwire.ConsumeWhitespace(d.buf[pos:])
 		if d.needMore(pos) {
 			if pos, err = d.consumeWhitespace(pos); err != nil {
-				return pos, err
+				return pos, wrapWithObjectName(err, quotedName)
 			}
 		}
 		pos, err = d.consumeValue(flags, pos, depth)
 		if err != nil {
-			return pos, err
+			return pos, wrapWithObjectName(err, quotedName)
 		}
 
 		// Handle after value.
@@ -941,7 +937,7 @@ func (d *decoderState) consumeObject(flags *jsonwire.ValueFlags, pos, depth int)
 			pos++
 			return pos, nil
 		default:
-			return pos, newInvalidCharacterError(d.buf[pos:], "after object value (expecting ',' or '}')")
+			return pos, jsonwire.NewInvalidCharacterError(d.buf[pos:], "after object value (expecting ',' or '}')")
 		}
 	}
 }
@@ -969,6 +965,7 @@ func (d *decoderState) consumeArray(flags *jsonwire.ValueFlags, pos, depth int) 
 		return pos, nil
 	}
 
+	var idx int64
 	depth++
 	for {
 		// Handle before value.
@@ -980,7 +977,7 @@ func (d *decoderState) consumeArray(flags *jsonwire.ValueFlags, pos, depth int) 
 		}
 		pos, err = d.consumeValue(flags, pos, depth)
 		if err != nil {
-			return pos, err
+			return pos, wrapWithArrayIndex(err, idx)
 		}
 
 		// Handle after value.
@@ -993,12 +990,13 @@ func (d *decoderState) consumeArray(flags *jsonwire.ValueFlags, pos, depth int) 
 		switch d.buf[pos] {
 		case ',':
 			pos++
+			idx++
 			continue
 		case ']':
 			pos++
 			return pos, nil
 		default:
-			return pos, newInvalidCharacterError(d.buf[pos:], "after array value (expecting ',' or ']')")
+			return pos, jsonwire.NewInvalidCharacterError(d.buf[pos:], "after array value (expecting ',' or ']')")
 		}
 	}
 }
@@ -1057,6 +1055,10 @@ func (d *Decoder) StackIndex(i int) (Kind, int64) {
 // Object names are only present if [AllowDuplicateNames] is false, otherwise
 // object members are represented using their index within the object.
 func (d *Decoder) StackPointer() Pointer {
-	d.s.Names.copyQuotedBuffer(d.s.buf)
-	return Pointer(d.s.appendStackPointer(nil))
+	return Pointer(d.s.AppendStackPointer(nil, -1))
+}
+
+func (d *decoderState) AppendStackPointer(b []byte, where int) []byte {
+	d.Names.copyQuotedBuffer(d.buf)
+	return d.state.appendStackPointer(b, where)
 }

--- a/jsontext/encode.go
+++ b/jsontext/encode.go
@@ -209,17 +209,7 @@ func (e *encoderState) Flush() error {
 
 	return nil
 }
-
-// injectSyntacticErrorWithPosition wraps a SyntacticError with the position,
-// otherwise it returns the error as is.
-// It takes a position relative to the start of the start of e.buf.
-func (e *encodeBuffer) injectSyntacticErrorWithPosition(err error, pos int) error {
-	if serr, ok := err.(*SyntacticError); ok {
-		return serr.withOffset(e.baseOffset + int64(pos))
-	}
-	return err
-}
-
+func (d *encodeBuffer) offsetAt(pos int) int64   { return d.baseOffset + int64(pos) }
 func (e *encodeBuffer) previousOffsetEnd() int64 { return e.baseOffset + int64(len(e.Buf)) }
 func (e *encodeBuffer) unflushedBuffer() []byte  { return e.Buf }
 
@@ -374,7 +364,7 @@ func (e *encoderState) WriteToken(t Token) error {
 					break
 				}
 				if e.Tokens.Last.isActiveNamespace() && !e.Namespaces.Last().insertQuoted(b[pos:], false) {
-					err = newDuplicateNameError(b[pos:])
+					err = wrapWithObjectName(ErrDuplicateName, b[pos:])
 					break
 				}
 			}
@@ -411,10 +401,10 @@ func (e *encoderState) WriteToken(t Token) error {
 		b = append(b, ']')
 		err = e.Tokens.popArray()
 	default:
-		err = &SyntacticError{str: "invalid json.Token"}
+		err = errInvalidToken
 	}
 	if err != nil {
-		return e.injectSyntacticErrorWithPosition(err, pos)
+		return wrapSyntacticError(e, err, pos, +1)
 	}
 
 	// Finish off the buffer and store it back into e.
@@ -464,7 +454,7 @@ func (e *encoderState) AppendRaw(k Kind, safeASCII bool, appendFn func([]byte) (
 			b, err = jsonwire.AppendQuote(b[:pos], string(b2), &e.Flags)
 			e.unusedCache = b2[:0]
 			if err != nil {
-				return e.injectSyntacticErrorWithPosition(err, pos)
+				return wrapSyntacticError(e, err, pos, +1)
 			}
 		}
 
@@ -472,24 +462,24 @@ func (e *encoderState) AppendRaw(k Kind, safeASCII bool, appendFn func([]byte) (
 		if e.Tokens.Last.NeedObjectName() {
 			if !e.Flags.Get(jsonflags.AllowDuplicateNames) {
 				if !e.Tokens.Last.isValidNamespace() {
-					return errInvalidNamespace
+					return wrapSyntacticError(e, err, pos, +1)
 				}
 				if e.Tokens.Last.isActiveNamespace() && !e.Namespaces.Last().insertQuoted(b[pos:], isVerbatim) {
-					err := newDuplicateNameError(b[pos:])
-					return e.injectSyntacticErrorWithPosition(err, pos)
+					err = wrapWithObjectName(ErrDuplicateName, b[pos:])
+					return wrapSyntacticError(e, err, pos, +1)
 				}
 			}
 			e.Names.ReplaceLastQuotedOffset(pos) // only replace if insertQuoted succeeds
 		}
 		if err := e.Tokens.appendString(); err != nil {
-			return e.injectSyntacticErrorWithPosition(err, pos)
+			return wrapSyntacticError(e, err, pos, +1)
 		}
 	case '0':
 		if b, err = appendFn(b); err != nil {
 			return err
 		}
 		if err := e.Tokens.appendNumber(); err != nil {
-			return e.injectSyntacticErrorWithPosition(err, pos)
+			return wrapSyntacticError(e, err, pos, +1)
 		}
 	default:
 		panic("BUG: invalid kind")
@@ -536,13 +526,13 @@ func (e *encoderState) WriteValue(v Value) error {
 	n += jsonwire.ConsumeWhitespace(v[n:])
 	b, m, err := e.reformatValue(b, v[n:], e.Tokens.Depth())
 	if err != nil {
-		return e.injectSyntacticErrorWithPosition(err, pos+n+m)
+		return wrapSyntacticError(e, err, pos+n+m, +1)
 	}
 	n += m
 	n += jsonwire.ConsumeWhitespace(v[n:])
 	if len(v) > n {
-		err = newInvalidCharacterError(v[n:], "after top-level value")
-		return e.injectSyntacticErrorWithPosition(err, pos+n)
+		err = jsonwire.NewInvalidCharacterError(v[n:], "after top-level value")
+		return wrapSyntacticError(e, err, pos+n, 0)
 	}
 
 	// Append the kind to the state machine.
@@ -557,7 +547,7 @@ func (e *encoderState) WriteValue(v Value) error {
 					break
 				}
 				if e.Tokens.Last.isActiveNamespace() && !e.Namespaces.Last().insertQuoted(b[pos:], false) {
-					err = newDuplicateNameError(b[pos:])
+					err = wrapWithObjectName(ErrDuplicateName, b[pos:])
 					break
 				}
 			}
@@ -582,7 +572,7 @@ func (e *encoderState) WriteValue(v Value) error {
 		}
 	}
 	if err != nil {
-		return e.injectSyntacticErrorWithPosition(err, pos)
+		return wrapSyntacticError(e, err, pos, +1)
 	}
 
 	// Finish off the buffer and store it back into e.
@@ -668,7 +658,7 @@ func (e *encoderState) reformatValue(dst []byte, src Value, depth int) ([]byte, 
 	case '[':
 		return e.reformatArray(dst, src, depth)
 	default:
-		return dst, 0, newInvalidCharacterError(src, "at start of value")
+		return dst, 0, jsonwire.NewInvalidCharacterError(src, "at start of value")
 	}
 }
 
@@ -727,17 +717,18 @@ func (e *encoderState) reformatObject(dst []byte, src Value, depth int) ([]byte,
 		}
 		quotedName := src[n : n+m]
 		if !e.Flags.Get(jsonflags.AllowDuplicateNames) && !names.insertQuoted(quotedName, isVerbatim) {
-			return dst, n, newDuplicateNameError(quotedName)
+			return dst, n, wrapWithObjectName(ErrDuplicateName, quotedName)
 		}
 		n += m
 
 		// Append colon.
 		n += jsonwire.ConsumeWhitespace(src[n:])
 		if uint(len(src)) <= uint(n) {
-			return dst, n, io.ErrUnexpectedEOF
+			return dst, n, wrapWithObjectName(io.ErrUnexpectedEOF, quotedName)
 		}
 		if src[n] != ':' {
-			return dst, n, newInvalidCharacterError(src[n:], "after object name (expecting ':')")
+			err = jsonwire.NewInvalidCharacterError(src[n:], "after object name (expecting ':')")
+			return dst, n, wrapWithObjectName(err, quotedName)
 		}
 		dst = append(dst, ':')
 		n += len(":")
@@ -748,11 +739,11 @@ func (e *encoderState) reformatObject(dst []byte, src Value, depth int) ([]byte,
 		// Append object value.
 		n += jsonwire.ConsumeWhitespace(src[n:])
 		if uint(len(src)) <= uint(n) {
-			return dst, n, io.ErrUnexpectedEOF
+			return dst, n, wrapWithObjectName(io.ErrUnexpectedEOF, quotedName)
 		}
 		dst, m, err = e.reformatValue(dst, src[n:], depth)
 		if err != nil {
-			return dst, n + m, err
+			return dst, n + m, wrapWithObjectName(err, quotedName)
 		}
 		n += m
 
@@ -777,7 +768,7 @@ func (e *encoderState) reformatObject(dst []byte, src Value, depth int) ([]byte,
 			n += len("}")
 			return dst, n, nil
 		default:
-			return dst, n, newInvalidCharacterError(src[n:], "after object value (expecting ',' or '}')")
+			return dst, n, jsonwire.NewInvalidCharacterError(src[n:], "after object value (expecting ',' or '}')")
 		}
 	}
 }
@@ -806,6 +797,7 @@ func (e *encoderState) reformatArray(dst []byte, src Value, depth int) ([]byte, 
 		return dst, n, nil
 	}
 
+	var idx int64
 	var err error
 	depth++
 	for {
@@ -822,7 +814,7 @@ func (e *encoderState) reformatArray(dst []byte, src Value, depth int) ([]byte, 
 		var m int
 		dst, m, err = e.reformatValue(dst, src[n:], depth)
 		if err != nil {
-			return dst, n + m, err
+			return dst, n + m, wrapWithArrayIndex(err, idx)
 		}
 		n += m
 
@@ -838,6 +830,7 @@ func (e *encoderState) reformatArray(dst []byte, src Value, depth int) ([]byte, 
 				dst = append(dst, ' ')
 			}
 			n += len(",")
+			idx++
 			continue
 		case ']':
 			if e.Flags.Get(jsonflags.Multiline) {
@@ -847,7 +840,7 @@ func (e *encoderState) reformatArray(dst []byte, src Value, depth int) ([]byte, 
 			n += len("]")
 			return dst, n, nil
 		default:
-			return dst, n, newInvalidCharacterError(src[n:], "after array value (expecting ',' or ']')")
+			return dst, n, jsonwire.NewInvalidCharacterError(src[n:], "after array value (expecting ',' or ']')")
 		}
 	}
 }
@@ -925,6 +918,10 @@ func (e *Encoder) StackIndex(i int) (Kind, int64) {
 // Object names are only present if [AllowDuplicateNames] is false, otherwise
 // object members are represented using their index within the object.
 func (e *Encoder) StackPointer() Pointer {
-	e.s.Names.copyQuotedBuffer(e.s.Buf)
-	return Pointer(e.s.appendStackPointer(nil))
+	return Pointer(e.s.AppendStackPointer(nil, -1))
+}
+
+func (e *encoderState) AppendStackPointer(b []byte, where int) []byte {
+	e.Names.copyQuotedBuffer(e.Buf)
+	return e.state.appendStackPointer(b, where)
 }

--- a/jsontext/errors.go
+++ b/jsontext/errors.go
@@ -5,6 +5,10 @@
 package jsontext
 
 import (
+	"bytes"
+	"io"
+	"strconv"
+
 	"github.com/go-json-experiment/json/internal/jsonwire"
 )
 
@@ -32,29 +36,138 @@ type SyntacticError struct {
 
 	// ByteOffset indicates that an error occurred after this byte offset.
 	ByteOffset int64
-	str        string
+	// JSONPointer indicates that an error occurred within this JSON value
+	// as indicated using the JSON Pointer notation (see RFC 6901).
+	JSONPointer Pointer
+
+	// Err is the underlying error.
+	Err error
+}
+
+// wrapSyntacticError wraps an error and annotates it with a precise location
+// using the provided [encoderState] or [decoderState].
+// If err is an [ioError] or [io.EOF], then it is not wrapped.
+//
+// It takes a relative offset pos that can be resolved into
+// an absolute offset using state.offsetAt.
+//
+// It takes a where that specify how the JSON pointer is derived.
+// If where is 0 and the next token is an object value,
+// then it the pointer implicitly upgraded to point at the next token.
+// If the underlying error is a [pointerSuffixError],
+// then the suffix is appended to the derived pointer.
+func wrapSyntacticError(state interface {
+	offsetAt(pos int) int64
+	needObjectValue() bool
+	AppendStackPointer(b []byte, where int) []byte
+}, err error, pos, where int) error {
+	if _, ok := err.(*ioError); err == io.EOF || ok {
+		return err
+	}
+	offset := state.offsetAt(pos)
+	if where == 0 && state.needObjectValue() {
+		where = +1
+	}
+	ptr := state.AppendStackPointer(nil, where)
+	if serr, ok := err.(*pointerSuffixError); ok {
+		ptr = serr.appendPointer(ptr)
+		err = serr.error
+	}
+	return &SyntacticError{ByteOffset: offset, JSONPointer: Pointer(ptr), Err: err}
 }
 
 func (e *SyntacticError) Error() string {
-	return errorPrefix + e.str
-}
-func (e *SyntacticError) withOffset(pos int64) error {
-	return &SyntacticError{ByteOffset: pos, str: e.str}
+	pointer := e.JSONPointer
+	offset := e.ByteOffset
+	b := []byte(errorPrefix)
+	if e.Err != nil {
+		b = append(b, e.Err.Error()...)
+		if e.Err == ErrDuplicateName {
+			b = strconv.AppendQuote(append(b, ' '), pointer.LastToken())
+			pointer = pointer.Parent()
+			offset = 0 // not useful to print offset for duplicate names
+		}
+	} else {
+		b = append(b, "syntactic error"...)
+	}
+	if pointer != "" {
+		// TODO: Truncate excessively long pointers.
+		b = strconv.AppendQuote(append(b, " within "...), string(pointer))
+	}
+	if offset > 0 {
+		b = strconv.AppendInt(append(b, " after offset "...), offset, 10)
+	}
+	return string(b)
 }
 
-func newDuplicateNameError[Bytes ~[]byte | ~string](quoted Bytes) *SyntacticError {
-	return &SyntacticError{str: "duplicate name " + string(quoted) + " in object"}
+func (e *SyntacticError) Unwrap() error {
+	return e.Err
 }
 
-func newInvalidCharacterError[Bytes ~[]byte | ~string](prefix Bytes, where string) *SyntacticError {
-	what := jsonwire.QuoteRune(prefix)
-	return &SyntacticError{str: "invalid character " + what + " " + where}
+// pointerSuffixError represents a JSON pointer suffix to be appended
+// to [SyntacticError.JSONPointer]. It is an internal error type
+// used within this package and does not appear in the public API.
+//
+// This type is primarily used to annotate errors in Encoder.WriteValue
+// and Decoder.ReadValue with precise positions.
+// At the time WriteValue or ReadValue is called, a JSON pointer to the
+// upcoming value can be constructed using the Encoder/Decoder state.
+// However, tracking pointers within values during normal operation
+// would incur a performance penalty in the error-free case.
+//
+// To provide precise error locations without this overhead,
+// the error is wrapped with object names or array indices
+// as the call stack is popped when an error occurs.
+// Since this happens in reverse order, pointerSuffixError holds
+// the pointer in reverse and is only later reversed when appending to
+// the pointer prefix.
+//
+// For example, if the encoder is at "/alpha/bravo/charlie"
+// and an error occurs in WriteValue at "/xray/yankee/zulu", then
+// the final pointer should be "/alpha/bravo/charlie/xray/yankee/zulu".
+//
+// As pointerSuffixError is populated during the error return path,
+// it first contains "/zulu", then "/zulu/yankee",
+// and finally "/zulu/yankee/xray".
+// These tokens are reversed and concatenated to "/alpha/bravo/charlie"
+// to form the full pointer.
+type pointerSuffixError struct {
+	error
+
+	// reversePointer is a JSON pointer, but with each token in reverse order.
+	reversePointer []byte
 }
 
-// TODO: Error types between "json", "jsontext", and "jsonwire" is a mess.
-// Clean this up.
-func init() {
-	// Inject behavior in "jsonwire" so that it can produce SyntacticError types.
-	jsonwire.NewError = func(s string) error { return &SyntacticError{str: s} }
-	jsonwire.ErrInvalidUTF8 = &SyntacticError{str: jsonwire.ErrInvalidUTF8.Error()}
+// wrapWithObjectName wraps err with a JSON object name access,
+// which must be a valid quoted JSON string.
+func wrapWithObjectName(err error, quotedName []byte) error {
+	serr, _ := err.(*pointerSuffixError)
+	if serr == nil {
+		serr = &pointerSuffixError{error: err}
+	}
+	name := jsonwire.UnquoteMayCopy(quotedName, false)
+	serr.reversePointer = appendEscapePointerName(append(serr.reversePointer, '/'), name)
+	return serr
+}
+
+// wrapWithArrayIndex wraps err with a JSON array index access.
+func wrapWithArrayIndex(err error, index int64) error {
+	serr, _ := err.(*pointerSuffixError)
+	if serr == nil {
+		serr = &pointerSuffixError{error: err}
+	}
+	serr.reversePointer = strconv.AppendUint(append(serr.reversePointer, '/'), uint64(index), 10)
+	return serr
+}
+
+// appendPointer appends the path encoded in e to the end of pointer.
+func (e *pointerSuffixError) appendPointer(pointer []byte) []byte {
+	// Copy each token in reversePointer to the end of pointer in reverse order.
+	// Double reversal means that the appended suffix is now in forward order.
+	bi, bo := e.reversePointer, pointer
+	for len(bi) > 0 {
+		i := bytes.LastIndexByte(bi, '/')
+		bi, bo = bi[:i], append(bo, bi[i:]...)
+	}
+	return bo
 }

--- a/jsontext/export.go
+++ b/jsontext/export.go
@@ -68,16 +68,3 @@ func (export) GetStreamingDecoder(r io.Reader, o ...Options) *Decoder {
 func (export) PutStreamingDecoder(d *Decoder) {
 	putStreamingDecoder(d)
 }
-
-func (export) NewDuplicateNameError(quoted []byte, pos int64) error {
-	return newDuplicateNameError(quoted).withOffset(pos)
-}
-func (export) NewInvalidCharacterError(prefix, where string, pos int64) error {
-	return newInvalidCharacterError(prefix, where).withOffset(pos)
-}
-func (export) NewMissingNameError(pos int64) error {
-	return errMissingName.withOffset(pos)
-}
-func (export) NewInvalidUTF8Error(pos int64) error {
-	return errInvalidUTF8.withOffset(pos)
-}

--- a/jsontext/fuzz_test.go
+++ b/jsontext/fuzz_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"io"
 	"math/rand"
-	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/go-json-experiment/json/internal/jsontest"
@@ -118,7 +118,7 @@ func FuzzResumableDecoder(f *testing.F) {
 			decWant := NewDecoder(bytes.NewReader(b))
 			gotTok, gotErr := decGot.ReadToken()
 			wantTok, wantErr := decWant.ReadToken()
-			if gotTok.String() != wantTok.String() || !reflect.DeepEqual(gotErr, wantErr) {
+			if gotTok.String() != wantTok.String() || !equalError(gotErr, wantErr) {
 				t.Errorf("Decoder.ReadToken = (%v, %v), want (%v, %v)", gotTok, gotErr, wantTok, wantErr)
 			}
 		})
@@ -127,7 +127,7 @@ func FuzzResumableDecoder(f *testing.F) {
 			decWant := NewDecoder(bytes.NewReader(b))
 			gotVal, gotErr := decGot.ReadValue()
 			wantVal, wantErr := decWant.ReadValue()
-			if !reflect.DeepEqual(gotVal, wantVal) || !reflect.DeepEqual(gotErr, wantErr) {
+			if !slices.Equal(gotVal, wantVal) || !equalError(gotErr, wantErr) {
 				t.Errorf("Decoder.ReadValue = (%s, %v), want (%s, %v)", gotVal, gotErr, wantVal, wantErr)
 			}
 		})

--- a/jsontext/quote.go
+++ b/jsontext/quote.go
@@ -9,15 +9,17 @@ import (
 	"github.com/go-json-experiment/json/internal/jsonwire"
 )
 
-var errInvalidUTF8 = &SyntacticError{str: "invalid UTF-8 within string"}
-
 // AppendQuote appends a double-quoted JSON string literal representing src
 // to dst and returns the extended buffer.
 // It uses the minimal string representation per RFC 8785, section 3.2.2.2.
 // Invalid UTF-8 bytes are replaced with the Unicode replacement character
 // and an error is returned at the end indicating the presence of invalid UTF-8.
 func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error) {
-	return jsonwire.AppendQuote(dst, src, &jsonflags.Flags{})
+	dst, err := jsonwire.AppendQuote(dst, src, &jsonflags.Flags{})
+	if err != nil {
+		err = &SyntacticError{Err: err}
+	}
+	return dst, err
 }
 
 // AppendUnquote appends the decoded interpretation of src as a
@@ -27,5 +29,9 @@ func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error)
 // and an error is returned at the end indicating the presence of invalid UTF-8.
 // Any trailing bytes after the JSON string literal results in an error.
 func AppendUnquote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error) {
-	return jsonwire.AppendUnquote(dst, src)
+	dst, err := jsonwire.AppendUnquote(dst, src)
+	if err != nil {
+		err = &SyntacticError{Err: err}
+	}
+	return dst, err
 }

--- a/jsontext/state.go
+++ b/jsontext/state.go
@@ -5,6 +5,7 @@
 package jsontext
 
 import (
+	"errors"
 	"iter"
 	"math"
 	"strconv"
@@ -14,14 +15,36 @@ import (
 )
 
 var (
-	errMissingName   = &SyntacticError{str: "missing string for object name"}
-	errMissingColon  = &SyntacticError{str: "missing character ':' after object name"}
-	errMissingValue  = &SyntacticError{str: "missing value after object name"}
-	errMissingComma  = &SyntacticError{str: "missing character ',' after object or array value"}
-	errMismatchDelim = &SyntacticError{str: "mismatching structural token for object or array"}
-	errMaxDepth      = &SyntacticError{str: "exceeded max depth"}
+	// ErrDuplicateName indicates that a JSON token could not be
+	// encoded or decoded because it results in a duplicate JSON object name.
+	// This error is wrapped within a [SyntacticError] when produced.
+	//
+	// The name of a duplicate JSON object member can be extracted as:
+	//
+	//	err := ...
+	//	var serr jsontext.SyntacticError
+	//	if errors.As(err, &serr) && serr.Err == jsontext.ErrDuplicateName {
+	//		ptr := serr.JSONPointer // JSON pointer to duplicate name
+	//		name := ptr.LastToken() // duplicate name itself
+	//		...
+	//	}
+	//
+	// This error is only returned if [AllowDuplicateNames] is false.
+	ErrDuplicateName = errors.New("duplicate object name")
 
-	errInvalidNamespace = &SyntacticError{str: "object namespace is in an invalid state"}
+	// ErrNonStringName indicates that a JSON token could not be
+	// encoded or decoded because it is not a string,
+	// as required for JSON object names according to RFC 8259, section 4.
+	// This error is wrapped within a [SyntacticError] when produced.
+	ErrNonStringName = errors.New("object name must be a string")
+
+	errMissingColon  = errors.New("missing character ':' after object name")
+	errMissingValue  = errors.New("missing value after object name")
+	errMissingComma  = errors.New("missing character ',' after object or array value")
+	errMismatchDelim = errors.New("mismatching structural token for object or array")
+	errMaxDepth      = errors.New("exceeded max depth")
+
+	errInvalidNamespace = errors.New("object namespace is in an invalid state")
 )
 
 // Per RFC 8259, section 9, implementations may enforce a maximum depth.
@@ -44,6 +67,12 @@ type state struct {
 	Namespaces objectNamespaceStack
 }
 
+// needObjectValue reports whether the next token should be an object value.
+// This method is used by [wrapSyntacticError].
+func (s *state) needObjectValue() bool {
+	return s.Tokens.Last.needObjectValue()
+}
+
 func (s *state) reset() {
 	s.Tokens.reset()
 	s.Names.reset()
@@ -58,6 +87,24 @@ func (s *state) reset() {
 // they both point to the exact same value.
 type Pointer string
 
+// Parent strips off the last token and returns the remaining pointer.
+// The parent of an empty p is an empty string.
+func (p Pointer) Parent() Pointer {
+	return p[:max(strings.LastIndexByte(string(p), '/'), 0)]
+}
+
+// LastToken returns the last token in the pointer.
+// The last token of an empty p is an empty string.
+func (p Pointer) LastToken() string {
+	last := p[max(strings.LastIndexByte(string(p), '/'), 0):]
+	return unescapePointerToken(strings.TrimPrefix(string(last), "/"))
+}
+
+// AppendToken appends a token to the end of p and returns the full pointer.
+func (p Pointer) AppendToken(tok string) Pointer {
+	return p + "/" + Pointer(appendEscapePointerName(nil, []byte(string([]rune(tok)))))
+}
+
 // Tokens returns an iterator over the reference tokens in the JSON pointer,
 // starting from the first token until the last token (unless stopped early).
 //
@@ -71,47 +118,67 @@ func (p Pointer) Tokens() iter.Seq[string] {
 		for len(p) > 0 {
 			p = Pointer(strings.TrimPrefix(string(p), "/"))
 			i := min(uint(strings.IndexByte(string(p), '/')), uint(len(p)))
-			token := string(p)[:i]
-			p = p[i:]
-			if strings.Contains(token, "~") {
-				// Per RFC 6901, section 3, unescape '~' and '/' characters.
-				token = strings.ReplaceAll(token, "~1", "/")
-				token = strings.ReplaceAll(token, "~0", "~")
-			}
-			if !yield(token) {
+			if !yield(unescapePointerToken(string(p)[:i])) {
 				return
 			}
+			p = p[i:]
 		}
 	}
 }
 
+func unescapePointerToken(token string) string {
+	if strings.Contains(token, "~") {
+		// Per RFC 6901, section 3, unescape '~' and '/' characters.
+		token = strings.ReplaceAll(token, "~1", "/")
+		token = strings.ReplaceAll(token, "~0", "~")
+	}
+	return token
+}
+
 // appendStackPointer appends a JSON Pointer (RFC 6901) to the current value.
 //
+// If where is -1, then it points to the previously processed token.
+// If where is 0, then it points to the parent JSON object or array.
+// If where is +1, then it points to the next expected token,
+// assuming that it continues the current JSON object or array.
+// As a special case, if the next token is a JSON object name,
+// then it points to the parent JSON object.
+//
 // Invariant: Must call s.names.copyQuotedBuffer beforehand.
-func (s state) appendStackPointer(b []byte) []byte {
+func (s state) appendStackPointer(b []byte, where int) []byte {
 	var objectDepth int
 	for i := 1; i < s.Tokens.Depth(); i++ {
 		e := s.Tokens.index(i)
-		if e.Length() == 0 {
-			break // empty object or array
+		arrayDelta := -1 // by default point to previous array element
+		if isLast := i == s.Tokens.Depth()-1; isLast {
+			switch {
+			case where < 0 && e.Length() == 0 || where == 0 || where > 0 && e.NeedObjectName():
+				return b
+			case where > 0 && e.isArray():
+				arrayDelta = 0 // point to next array element
+			}
 		}
-		b = append(b, '/')
 		switch {
 		case e.isObject():
-			for _, c := range s.Names.getUnquoted(objectDepth) {
-				// Per RFC 6901, section 3, escape '~' and '/' characters.
-				switch c {
-				case '~':
-					b = append(b, "~0"...)
-				case '/':
-					b = append(b, "~1"...)
-				default:
-					b = append(b, c)
-				}
-			}
+			b = appendEscapePointerName(append(b, '/'), s.Names.getUnquoted(objectDepth))
 			objectDepth++
 		case e.isArray():
-			b = strconv.AppendUint(b, uint64(e.Length()-1), 10)
+			b = strconv.AppendUint(append(b, '/'), uint64(e.Length()+int64(arrayDelta)), 10)
+		}
+	}
+	return b
+}
+
+func appendEscapePointerName(b, name []byte) []byte {
+	for _, c := range name {
+		// Per RFC 6901, section 3, escape '~' and '/' characters.
+		switch c {
+		case '~':
+			b = append(b, "~0"...)
+		case '/':
+			b = append(b, "~1"...)
+		default:
+			b = append(b, c)
 		}
 	}
 	return b
@@ -170,7 +237,7 @@ func (m stateMachine) DepthLength() (int, int64) {
 func (m *stateMachine) appendLiteral() error {
 	switch {
 	case m.Last.NeedObjectName():
-		return errMissingName
+		return ErrNonStringName
 	case !m.Last.isValidNamespace():
 		return errInvalidNamespace
 	default:
@@ -202,7 +269,7 @@ func (m *stateMachine) appendNumber() error {
 func (m *stateMachine) pushObject() error {
 	switch {
 	case m.Last.NeedObjectName():
-		return errMissingName
+		return ErrNonStringName
 	case !m.Last.isValidNamespace():
 		return errInvalidNamespace
 	case len(m.Stack) == maxNestingDepth:
@@ -237,7 +304,7 @@ func (m *stateMachine) popObject() error {
 func (m *stateMachine) pushArray() error {
 	switch {
 	case m.Last.NeedObjectName():
-		return errMissingName
+		return ErrNonStringName
 	case !m.Last.isValidNamespace():
 		return errInvalidNamespace
 	case len(m.Stack) == maxNestingDepth:
@@ -322,7 +389,7 @@ func (m stateMachine) checkDelim(delim byte, next Kind) error {
 	case ',':
 		return errMissingComma
 	default:
-		return newInvalidCharacterError([]byte{delim}, "before next token")
+		return jsonwire.NewInvalidCharacterError([]byte{delim}, "before next token")
 	}
 }
 

--- a/jsontext/token.go
+++ b/jsontext/token.go
@@ -6,6 +6,7 @@ package jsontext
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"strconv"
 
@@ -23,6 +24,8 @@ const (
 
 	invalidTokenPanic = "invalid json.Token; it has been voided by a subsequent json.Decoder call"
 )
+
+var errInvalidToken = errors.New("invalid jsontext.Token")
 
 // Token represents a lexical JSON token, which may be one of the following:
 //   - a JSON literal (i.e., null, true, or false)


### PR DESCRIPTION
Make SyntacticError precise about the position of the error by also recording the JSON pointer.

Other changes:
* Make SyntacticError wrap an error.
* Export ErrDuplicateName as a means to programmatically identify a duplicate object name error.
* Export ErrNonStringName to indicate a syntax error when the expected JSON object name is not a string.
* Always wrap io.ErrUnexpectedEOF in SyntacticError.
* Avoid any dependency injection between jsontext and jsonwire.
* Add convenience methods to jsontext.Pointer.