### PR TITLE
Improve error positioning of SemanticError

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -428,6 +428,8 @@ func UnmarshalDecode(in *jsontext.Decoder, out any, opts ...Options) (err error)
 	return unmarshalDecode(in, out, uo)
 }
 
+var errNonNilReference = errors.New("value must be passed as a non-nil pointer reference")
+
 func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct) (err error) {
 	v := reflect.ValueOf(out)
 	if !v.IsValid() || v.Kind() != reflect.Pointer || v.IsNil() {
@@ -438,8 +440,7 @@ func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct) (err er
 				t = t.Elem()
 			}
 		}
-		err := errors.New("value must be passed as a non-nil pointer reference")
-		return &SemanticError{action: "unmarshal", GoType: t, Err: err}
+		return &SemanticError{action: "unmarshal", GoType: t, Err: errNonNilReference}
 	}
 	va := addressableValue{v.Elem()} // dereferenced pointer is always addressable
 	t := va.Type()

--- a/arshal_funcs.go
+++ b/arshal_funcs.go
@@ -24,6 +24,9 @@ import (
 // [jsontext.Encoder.WriteToken] since such methods mutate the state.
 var SkipFunc = errors.New("json: skip function")
 
+var errSkipMutation = errors.New("must not read or write any tokens when skipping")
+var errNonSingularValue = errors.New("must read or write exactly one value")
+
 // Marshalers is a list of functions that may override the marshal behavior
 // of specific types. Populate [WithMarshalers] to use it with
 // [Marshal], [MarshalWrite], or [MarshalEncode].
@@ -174,12 +177,14 @@ func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
 			val, err := fn(va.castTo(t).Interface().(T))
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal function of type func(T) ([]byte, error)")
-				// TODO: Avoid wrapping semantic errors.
-				return &SemanticError{action: "marshal", GoType: t, Err: err}
+				err = newMarshalErrorBefore(enc, t, err)
+				return collapseSemanticErrors(err)
 			}
 			if err := enc.WriteValue(val); err != nil {
-				// TODO: Avoid wrapping semantic or I/O errors.
-				return &SemanticError{action: "marshal", JSONKind: jsontext.Value(val).Kind(), GoType: t, Err: err}
+				if isSyntacticError(err) {
+					err = newMarshalErrorBefore(enc, t, err)
+				}
+				return err
 			}
 			return nil
 		},
@@ -212,17 +217,19 @@ func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshal
 			xe.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xe.Tokens.DepthLength()
 			if err == nil && (prevDepth != currDepth || prevLength+1 != currLength) {
-				err = errors.New("must write exactly one JSON value")
+				err = errNonSingularValue
 			}
 			if err != nil {
 				if err == SkipFunc {
 					if prevDepth == currDepth && prevLength == currLength {
 						return SkipFunc
 					}
-					err = errors.New("must not write any JSON tokens when skipping")
+					err = errSkipMutation
 				}
-				// TODO: Avoid wrapping semantic or I/O errors.
-				return &SemanticError{action: "marshal", GoType: t, Err: err}
+				if !export.IsIOError(err) {
+					err = newSemanticErrorWithPosition(enc, t, prevDepth, prevLength, err)
+				}
+				return err
 			}
 			return nil
 		},
@@ -253,8 +260,8 @@ func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
 			err = fn(val, va.castTo(t).Interface().(T))
 			if err != nil {
 				err = wrapSkipFunc(err, "unmarshal function of type func([]byte, T) error")
-				// TODO: Avoid wrapping semantic, syntactic, or I/O errors.
-				return &SemanticError{action: "unmarshal", JSONKind: val.Kind(), GoType: t, Err: err}
+				err = newUnmarshalErrorAfter(dec, t, err)
+				return collapseSemanticErrors(err)
 			}
 			return nil
 		},
@@ -286,17 +293,19 @@ func UnmarshalFuncV2[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmar
 			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xd.Tokens.DepthLength()
 			if err == nil && (prevDepth != currDepth || prevLength+1 != currLength) {
-				err = errors.New("must read exactly one JSON value")
+				err = errNonSingularValue
 			}
 			if err != nil {
 				if err == SkipFunc {
 					if prevDepth == currDepth && prevLength == currLength {
 						return SkipFunc
 					}
-					err = errors.New("must not read any JSON tokens when skipping")
+					err = errSkipMutation
 				}
-				// TODO: Avoid wrapping semantic, syntactic, or I/O errors.
-				return &SemanticError{action: "unmarshal", GoType: t, Err: err}
+				if !isSyntacticError(err) && !export.IsIOError(err) {
+					err = newSemanticErrorWithPosition(dec, t, prevDepth, prevLength, err)
+				}
+				return err
 			}
 			return nil
 		},

--- a/arshal_time.go
+++ b/arshal_time.go
@@ -45,7 +45,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var m durationArshaler
 			if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
 				if !m.initFormat(mo.Format) {
-					return newInvalidFormatError("marshal", t, mo.Format)
+					return newInvalidFormatError(enc, t, mo.Format)
 				}
 			} else if mo.Flags.Get(jsonflags.FormatTimeDurationAsNanosecond) {
 				return marshalNano(enc, va, mo)
@@ -55,7 +55,10 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			m.td = *va.Addr().Interface().(*time.Duration)
 			k := stringOrNumberKind(!m.isNumeric() || mo.Flags.Get(jsonflags.StringifyNumbers))
 			if err := xe.AppendRaw(k, true, m.appendMarshal); err != nil {
-				return &SemanticError{action: "marshal", GoType: t, Err: err}
+				if !isSyntacticError(err) && !export.IsIOError(err) {
+					err = newMarshalErrorBefore(enc, t, err)
+				}
+				return err
 			}
 			return nil
 		}
@@ -65,7 +68,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var u durationArshaler
 			if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
 				if !u.initFormat(uo.Format) {
-					return newInvalidFormatError("unmarshal", t, uo.Format)
+					return newInvalidFormatError(dec, t, uo.Format)
 				}
 			} else if uo.Flags.Get(jsonflags.FormatTimeDurationAsNanosecond) {
 				return unmarshalNano(dec, va, uo)
@@ -83,26 +86,25 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				return nil
 			case '"':
 				if u.isNumeric() && !uo.Flags.Get(jsonflags.StringifyNumbers) {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t}
+					break
 				}
 				val = jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 				if err := u.unmarshal(val); err != nil {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t, Err: err}
+					return newUnmarshalErrorAfter(dec, t, err)
 				}
 				*td = u.td
 				return nil
 			case '0':
 				if !u.isNumeric() {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t}
+					break
 				}
 				if err := u.unmarshal(val); err != nil {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t, Err: err}
+					return newUnmarshalErrorAfter(dec, t, err)
 				}
 				*td = u.td
 				return nil
-			default:
-				return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t}
 			}
+			return newUnmarshalErrorAfter(dec, t, nil)
 		}
 	case timeTimeType:
 		fncs.nonDefault = true
@@ -111,7 +113,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var m timeArshaler
 			if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
 				if !m.initFormat(mo.Format) {
-					return newInvalidFormatError("marshal", t, mo.Format)
+					return newInvalidFormatError(enc, t, mo.Format)
 				}
 			}
 
@@ -119,7 +121,10 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			m.tt = *va.Addr().Interface().(*time.Time)
 			k := stringOrNumberKind(!m.isNumeric() || mo.Flags.Get(jsonflags.StringifyNumbers))
 			if err := xe.AppendRaw(k, !m.hasCustomFormat(), m.appendMarshal); err != nil {
-				return &SemanticError{action: "marshal", GoType: t, Err: err}
+				if !isSyntacticError(err) && !export.IsIOError(err) {
+					err = newMarshalErrorBefore(enc, t, err)
+				}
+				return err
 			}
 			return nil
 		}
@@ -128,7 +133,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var u timeArshaler
 			if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
 				if !u.initFormat(uo.Format) {
-					return newInvalidFormatError("unmarshal", t, uo.Format)
+					return newInvalidFormatError(dec, t, uo.Format)
 				}
 			}
 
@@ -144,26 +149,25 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				return nil
 			case '"':
 				if u.isNumeric() && !uo.Flags.Get(jsonflags.StringifyNumbers) {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t}
+					break
 				}
 				val = jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
 				if err := u.unmarshal(val); err != nil {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t, Err: err}
+					return newUnmarshalErrorAfter(dec, t, err)
 				}
 				*tt = u.tt
 				return nil
 			case '0':
 				if !u.isNumeric() {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t}
+					break
 				}
 				if err := u.unmarshal(val); err != nil {
-					return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t, Err: err}
+					return newUnmarshalErrorAfter(dec, t, err)
 				}
 				*tt = u.tt
 				return nil
-			default:
-				return &SemanticError{action: "unmarshal", JSONKind: k, GoType: t}
 			}
+			return newUnmarshalErrorAfter(dec, t, nil)
 		}
 	}
 	return fncs

--- a/errors.go
+++ b/errors.go
@@ -5,15 +5,46 @@
 package json
 
 import (
+	"cmp"
+	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/go-json-experiment/json/internal/jsonwire"
 	"github.com/go-json-experiment/json/jsontext"
 )
 
+// ErrUnknownName indicates that a JSON object member could not be
+// unmarshaled because the name is not known to the target Go struct.
+// This error is directly wrapped within a [SemanticError] when produced.
+//
+// The name of an unknown JSON object member can be extracted as:
+//
+//	err := ...
+//	var serr json.SemanticError
+//	if errors.As(err, &serr) && serr.Err == json.ErrUnknownName {
+//		ptr := serr.JSONPointer // JSON pointer to unknown name
+//		name := ptr.LastToken() // unknown name itself
+//		...
+//	}
+//
+// This error is only returned if [RejectUnknownMembers] is true.
+var ErrUnknownName = errors.New("unknown object member name")
+
 const errorPrefix = "json: "
+
+func isSemanticError(err error) bool {
+	_, ok := err.(*SemanticError)
+	return ok
+}
+
+func isSyntacticError(err error) bool {
+	_, ok := err.(*jsontext.SyntacticError)
+	return ok
+}
 
 // SemanticError describes an error determining the meaning
 // of JSON data as Go data or vice-versa.
@@ -40,18 +71,175 @@ type SemanticError struct {
 	Err error // may be nil
 }
 
+// coder is implemented by [jsontext.Encoder] or [jsontext.Decoder].
+type coder interface{ StackPointer() jsontext.Pointer }
+
+// newInvalidFormatError wraps err in a SemanticError because
+// the current type t cannot handle the provided format flag.
+func newInvalidFormatError(c coder, t reflect.Type, format string) error {
+	err := fmt.Errorf("invalid format flag %q", format)
+	switch c := c.(type) {
+	case *jsontext.Encoder:
+		err = newMarshalErrorBefore(c, t, err)
+	case *jsontext.Decoder:
+		err = newUnmarshalErrorBefore(c, t, err)
+	}
+	return err
+}
+
+// newMarshalErrorBefore wraps err in a SemanticError assuming that e
+// is positioned right before the next token or value, which causes an error.
+func newMarshalErrorBefore(e *jsontext.Encoder, t reflect.Type, err error) error {
+	return &SemanticError{action: "marshal", GoType: t, Err: err,
+		ByteOffset:  e.OutputOffset() + int64(export.Encoder(e).CountNextDelimWhitespace()),
+		JSONPointer: jsontext.Pointer(export.Encoder(e).AppendStackPointer(nil, +1))}
+}
+
+// newUnmarshalErrorBefore wraps err in a SemanticError assuming that d
+// is positioned right before the next token or value, which causes an error.
+func newUnmarshalErrorBefore(d *jsontext.Decoder, t reflect.Type, err error) error {
+	return &SemanticError{action: "unmarshal", GoType: t, Err: err,
+		ByteOffset:  d.InputOffset() + int64(export.Decoder(d).CountNextDelimWhitespace()),
+		JSONPointer: jsontext.Pointer(export.Decoder(d).AppendStackPointer(nil, +1)),
+		JSONKind:    d.PeekKind()}
+}
+
+// newUnmarshalErrorAfter wraps err in a SemanticError assuming that d
+// is positioned right after the previous token or value, which caused an error.
+func newUnmarshalErrorAfter(d *jsontext.Decoder, t reflect.Type, err error) error {
+	tokOrVal := export.Decoder(d).PreviousTokenOrValue()
+	return &SemanticError{action: "unmarshal", GoType: t, Err: err,
+		ByteOffset:  d.InputOffset() - int64(len(tokOrVal)),
+		JSONPointer: jsontext.Pointer(export.Decoder(d).AppendStackPointer(nil, -1)),
+		JSONKind:    jsontext.Value(tokOrVal).Kind()}
+}
+
+// newSemanticErrorWithPosition wraps err in a SemanticError assuming that
+// the error occurred at the provided depth, and length.
+// If err is already a SemanticError, then position information is only
+// injected if it is currently unpopulated.
+//
+// If the position is unpopulated, it is ambiguous where the error occurred
+// in the user code, whether it was before or after the current position.
+// For the byte offset, we assume that the error occurred before the last read
+// token or value when decoding, or before the next value when encoding.
+// For the JSON pointer, we point to the parent object or array unless
+// we can be certain that it happened with an object member.
+//
+// This is used to annotate errors returned by user-provided
+// v2 MarshalJSON or UnmarshalJSON methods or functions.
+func newSemanticErrorWithPosition(c coder, t reflect.Type, prevDepth int, prevLength int64, err error) error {
+	serr, _ := err.(*SemanticError)
+	if serr == nil {
+		serr = &SemanticError{Err: err}
+	}
+	var currDepth int
+	var currLength int64
+	var coderState interface{ AppendStackPointer([]byte, int) []byte }
+	var offset int64
+	switch c := c.(type) {
+	case *jsontext.Encoder:
+		e := export.Encoder(c)
+		serr.action = cmp.Or(serr.action, "marshal")
+		currDepth, currLength = e.Tokens.DepthLength()
+		offset = c.OutputOffset() + int64(export.Encoder(c).CountNextDelimWhitespace())
+		coderState = e
+	case *jsontext.Decoder:
+		d := export.Decoder(c)
+		serr.action = cmp.Or(serr.action, "unmarshal")
+		currDepth, currLength = d.Tokens.DepthLength()
+		tokOrVal := d.PreviousTokenOrValue()
+		offset = c.InputOffset() - int64(len(tokOrVal))
+		if (prevDepth == currDepth && prevLength == currLength) || len(tokOrVal) == 0 {
+			// If no Read method was called in the user-defined method or
+			// if the Peek method was called, then use the offset of the next value.
+			offset = c.InputOffset() + int64(export.Decoder(c).CountNextDelimWhitespace())
+		}
+		coderState = d
+	}
+	serr.ByteOffset = cmp.Or(serr.ByteOffset, offset)
+	if serr.JSONPointer == "" {
+		where := 0 // default to ambiguous positioning
+		switch {
+		case prevDepth == currDepth && prevLength+0 == currLength:
+			where = +1
+		case prevDepth == currDepth && prevLength+1 == currLength:
+			where = -1
+		}
+		serr.JSONPointer = jsontext.Pointer(coderState.AppendStackPointer(nil, where))
+	}
+	serr.GoType = cmp.Or(serr.GoType, t)
+	return serr
+}
+
+// collapseSemanticErrors collapses double SemanticErrors at the outer levels
+// into a single SemanticError by preserving the inner error,
+// but prepending the ByteOffset and JSONPointer with the outer error.
+//
+// For example:
+//
+//	collapseSemanticErrors(&SemanticError{
+//		ByteOffset:  len64(`[0,{"alpha":[0,1,`),
+//		JSONPointer: "/1/alpha/2",
+//		GoType:      reflect.TypeFor[outerType](),
+//		Err: &SemanticError{
+//			ByteOffset:  len64(`{"foo":"bar","fizz":[0,`),
+//			JSONPointer: "/fizz/1",
+//			GoType:      reflect.TypeFor[innerType](),
+//			Err:         ...,
+//		},
+//	})
+//
+// results in:
+//
+//	&SemanticError{
+//		ByteOffset:  len64(`[0,{"alpha":[0,1,`) + len64(`{"foo":"bar","fizz":[0,`),
+//		JSONPointer: "/1/alpha/2" + "/fizz/1",
+//		GoType:      reflect.TypeFor[innerType](),
+//		Err:         ...,
+//	}
+//
+// This is used to annotate errors returned by user-provided
+// v1 MarshalJSON or UnmarshalJSON methods with precise position information
+// if they themselves happened to return a SemanticError.
+// Since MarshalJSON and UnmarshalJSON are not operating on the root JSON value,
+// their positioning must be relative to the nested JSON value
+// returned by UnmarshalJSON or passed to MarshalJSON.
+// Therefore, we can construct an absolute position by concatenating
+// the outer with the inner positions.
+//
+// Note that we do not use collapseSemanticErrors with user-provided functions
+// that take in an [jsontext.Encoder] or [jsontext.Decoder] since they contain
+// methods to report position relative to the root JSON value.
+// We assume user-constructed errors are correctly precise about position.
+func collapseSemanticErrors(err error) error {
+	if serr1, ok := err.(*SemanticError); ok {
+		if serr2, ok := serr1.Err.(*SemanticError); ok {
+			serr2.ByteOffset = serr1.ByteOffset + serr2.ByteOffset
+			serr2.JSONPointer = serr1.JSONPointer + serr2.JSONPointer
+			*serr1 = *serr2
+		}
+	}
+	return err
+}
+
+// errorModalVerb is a modal verb like "cannot" or "unable to".
+//
+// Once per process, Hyrum-proof the error message by deliberately
+// switching between equivalent renderings of the same error message.
+// The randomization is tied to the Hyrum-proofing already applied
+// on map iteration in Go.
+var errorModalVerb = sync.OnceValue(func() string {
+	for phrase := range map[string]struct{}{"cannot": {}, "unable to": {}} {
+		return phrase // use whichever phrase we get in the first iteration
+	}
+	return ""
+})
+
 func (e *SemanticError) Error() string {
 	var sb strings.Builder
 	sb.WriteString(errorPrefix)
-
-	// Hyrum-proof the error message by deliberately switching between
-	// two equivalent renderings of the same error message.
-	// The randomization is tied to the Hyrum-proofing already applied
-	// on map iteration in Go.
-	for phrase := range map[string]struct{}{"cannot": {}, "unable to": {}} {
-		sb.WriteString(phrase)
-		break // use whichever phrase we get in the first iteration
-	}
+	sb.WriteString(errorModalVerb())
 
 	// Format action.
 	var preposition string
@@ -68,7 +256,6 @@ func (e *SemanticError) Error() string {
 	}
 
 	// Format JSON kind.
-	var omitPreposition bool
 	switch e.JSONKind {
 	case 'n':
 		sb.WriteString(" JSON null")
@@ -83,36 +270,76 @@ func (e *SemanticError) Error() string {
 	case '[', ']':
 		sb.WriteString(" JSON array")
 	default:
-		omitPreposition = true
+		if e.action == "" {
+			preposition = ""
+		}
 	}
 
 	// Format Go type.
 	if e.GoType != nil {
-		if !omitPreposition {
-			sb.WriteString(preposition)
+		typeString := e.GoType.String()
+		if len(typeString) > 100 {
+			// An excessively long type string most likely occurs for
+			// an anonymous struct declaration with many fields.
+			// Reduce the noise by just printing the kind,
+			// and optionally prepending it with the package name
+			// if the struct happens to include an unexported field.
+			typeString = e.GoType.Kind().String()
+			if e.GoType.Kind() == reflect.Struct && e.GoType.Name() == "" {
+				for i := range e.GoType.NumField() {
+					if pkgPath := e.GoType.Field(i).PkgPath; pkgPath != "" {
+						typeString = pkgPath[strings.LastIndexByte(pkgPath, '/')+len("/"):] + ".struct"
+						break
+					}
+				}
+			}
 		}
-		sb.WriteString(" Go value of type ")
-		sb.WriteString(e.GoType.String())
+		sb.WriteString(preposition)
+		sb.WriteString(" Go ")
+		sb.WriteString(typeString)
+	}
+
+	// Special handling for unknown names.
+	if e.Err == ErrUnknownName {
+		sb.WriteString(": ")
+		sb.WriteString(ErrUnknownName.Error())
+		sb.WriteString(" ")
+		sb.WriteString(strconv.Quote(e.JSONPointer.LastToken()))
+		if parent := e.JSONPointer.Parent(); parent != "" {
+			sb.WriteString(" within ")
+			sb.WriteString(strconv.Quote(jsonwire.TruncatePointer(string(parent), 100)))
+		}
+		return sb.String()
 	}
 
 	// Format where.
-	switch {
+	// Avoid printing if it overlaps with a wrapped SyntacticError.
+	switch serr, _ := e.Err.(*jsontext.SyntacticError); {
 	case e.JSONPointer != "":
-		sb.WriteString(" within JSON value at ")
-		sb.WriteString(strconv.Quote(jsonwire.TruncatePointer(string(e.JSONPointer), 100)))
+		if serr == nil || !e.JSONPointer.Contains(serr.JSONPointer) {
+			sb.WriteString(" within ")
+			sb.WriteString(strconv.Quote(jsonwire.TruncatePointer(string(e.JSONPointer), 100)))
+		}
 	case e.ByteOffset > 0:
-		sb.WriteString(" after byte offset ")
-		sb.WriteString(strconv.FormatInt(e.ByteOffset, 10))
+		if serr == nil || !(e.ByteOffset <= serr.ByteOffset) {
+			sb.WriteString(" after offset ")
+			sb.WriteString(strconv.FormatInt(e.ByteOffset, 10))
+		}
 	}
 
 	// Format underlying error.
 	if e.Err != nil {
+		errString := e.Err.Error()
+		if isSyntacticError(e.Err) {
+			errString = strings.TrimPrefix(errString, "jsontext: ")
+		}
 		sb.WriteString(": ")
-		sb.WriteString(e.Err.Error())
+		sb.WriteString(errString)
 	}
 
 	return sb.String()
 }
+
 func (e *SemanticError) Unwrap() error {
 	return e.Err
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -9,9 +9,11 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/go-json-experiment/json/internal/jsonwire"
+	"github.com/go-json-experiment/json/jsontext"
 )
 
 func TestSemanticError(t *testing.T) {
@@ -20,55 +22,79 @@ func TestSemanticError(t *testing.T) {
 		want string
 	}{{
 		err:  &SemanticError{},
-		want: "json: cannot handle",
+		want: `json: cannot handle`,
 	}, {
 		err:  &SemanticError{JSONKind: 'n'},
-		want: "json: cannot handle JSON null",
+		want: `json: cannot handle JSON null`,
 	}, {
 		err:  &SemanticError{action: "unmarshal", JSONKind: 't'},
-		want: "json: cannot unmarshal JSON boolean",
+		want: `json: cannot unmarshal JSON boolean`,
 	}, {
 		err:  &SemanticError{action: "unmarshal", JSONKind: 'x'},
-		want: "json: cannot unmarshal", // invalid token kinds are ignored
+		want: `json: cannot unmarshal`, // invalid token kinds are ignored
 	}, {
 		err:  &SemanticError{action: "marshal", JSONKind: '"'},
-		want: "json: cannot marshal JSON string",
+		want: `json: cannot marshal JSON string`,
 	}, {
-		err:  &SemanticError{GoType: reflect.TypeFor[bool]()},
-		want: "json: cannot handle Go value of type bool",
+		err:  &SemanticError{GoType: T[bool]()},
+		want: `json: cannot handle Go bool`,
 	}, {
-		err:  &SemanticError{action: "marshal", GoType: reflect.TypeFor[int]()},
-		want: "json: cannot marshal Go value of type int",
+		err:  &SemanticError{action: "marshal", GoType: T[int]()},
+		want: `json: cannot marshal from Go int`,
 	}, {
-		err:  &SemanticError{action: "unmarshal", GoType: reflect.TypeFor[uint]()},
-		want: "json: cannot unmarshal Go value of type uint",
+		err:  &SemanticError{action: "unmarshal", GoType: T[uint]()},
+		want: `json: cannot unmarshal into Go uint`,
 	}, {
-		err:  &SemanticError{JSONKind: '0', GoType: reflect.TypeFor[tar.Header]()},
-		want: "json: cannot handle JSON number with Go value of type tar.Header",
+		err:  &SemanticError{GoType: T[struct{ Alpha, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel string }]()},
+		want: `json: cannot handle Go struct`,
 	}, {
-		err:  &SemanticError{action: "marshal", JSONKind: '{', GoType: reflect.TypeFor[bytes.Buffer]()},
-		want: "json: cannot marshal JSON object from Go value of type bytes.Buffer",
+		err:  &SemanticError{GoType: T[struct{ Alpha, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, x string }]()},
+		want: `json: cannot handle Go json.struct`,
 	}, {
-		err:  &SemanticError{action: "unmarshal", JSONKind: ']', GoType: reflect.TypeFor[strings.Reader]()},
-		want: "json: cannot unmarshal JSON array into Go value of type strings.Reader",
+		err:  &SemanticError{JSONKind: '0', GoType: T[tar.Header]()},
+		want: `json: cannot handle JSON number with Go tar.Header`,
 	}, {
-		err:  &SemanticError{action: "unmarshal", JSONKind: '{', GoType: reflect.TypeFor[float64](), ByteOffset: 123},
-		want: "json: cannot unmarshal JSON object into Go value of type float64 after byte offset 123",
+		err:  &SemanticError{action: "marshal", JSONKind: '{', GoType: T[bytes.Buffer]()},
+		want: `json: cannot marshal JSON object from Go bytes.Buffer`,
 	}, {
-		err:  &SemanticError{action: "marshal", JSONKind: 'f', GoType: reflect.TypeFor[complex128](), ByteOffset: 123, JSONPointer: "/foo/2/bar/3"},
-		want: "json: cannot marshal JSON boolean from Go value of type complex128 within JSON value at \"/foo/2/bar/3\"",
+		err:  &SemanticError{action: "unmarshal", JSONKind: ']', GoType: T[strings.Reader]()},
+		want: `json: cannot unmarshal JSON array into Go strings.Reader`,
 	}, {
-		err:  &SemanticError{action: "unmarshal", JSONKind: '}', GoType: reflect.TypeFor[io.Reader](), ByteOffset: 123, JSONPointer: "/foo/2/bar/3", Err: errors.New("some underlying error")},
-		want: "json: cannot unmarshal JSON object into Go value of type io.Reader within JSON value at \"/foo/2/bar/3\": some underlying error",
+		err:  &SemanticError{action: "unmarshal", JSONKind: '{', GoType: T[float64](), ByteOffset: 123},
+		want: `json: cannot unmarshal JSON object into Go float64 after offset 123`,
+	}, {
+		err:  &SemanticError{action: "marshal", JSONKind: 'f', GoType: T[complex128](), ByteOffset: 123, JSONPointer: "/foo/2/bar/3"},
+		want: `json: cannot marshal JSON boolean from Go complex128 within "/foo/2/bar/3"`,
+	}, {
+		err:  &SemanticError{action: "unmarshal", JSONKind: '}', GoType: T[io.Reader](), ByteOffset: 123, JSONPointer: "/foo/2/bar/3", Err: errors.New("some underlying error")},
+		want: `json: cannot unmarshal JSON object into Go io.Reader within "/foo/2/bar/3": some underlying error`,
 	}, {
 		err:  &SemanticError{Err: errors.New("some underlying error")},
-		want: "json: cannot handle: some underlying error",
+		want: `json: cannot handle: some underlying error`,
 	}, {
 		err:  &SemanticError{ByteOffset: 123},
-		want: "json: cannot handle after byte offset 123",
+		want: `json: cannot handle after offset 123`,
 	}, {
 		err:  &SemanticError{JSONPointer: "/foo/2/bar/3"},
-		want: "json: cannot handle within JSON value at \"/foo/2/bar/3\"",
+		want: `json: cannot handle within "/foo/2/bar/3"`,
+	}, {
+		err:  &SemanticError{action: "unmarshal", JSONPointer: "/3", GoType: T[struct{ Fizz, Buzz string }](), Err: ErrUnknownName},
+		want: `json: cannot unmarshal into Go struct { Fizz string; Buzz string }: unknown object member name "3"`,
+	}, {
+		err:  &SemanticError{action: "unmarshal", JSONPointer: "/foo/2/bar/3", GoType: T[struct{ Foo string }](), Err: ErrUnknownName},
+		want: `json: cannot unmarshal into Go struct { Foo string }: unknown object member name "3" within "/foo/2/bar"`,
+	}, {
+		err:  &SemanticError{JSONPointer: "/foo/bar", ByteOffset: 16, GoType: T[string](), Err: &jsontext.SyntacticError{JSONPointer: "/foo/bar/baz", ByteOffset: 53, Err: jsonwire.ErrInvalidUTF8}},
+		want: `json: cannot handle Go string: invalid UTF-8 within "/foo/bar/baz" after offset 53`,
+	}, {
+		err:  &SemanticError{JSONPointer: "/fizz/bar", ByteOffset: 16, GoType: T[string](), Err: &jsontext.SyntacticError{JSONPointer: "/foo/bar/baz", ByteOffset: 53, Err: jsonwire.ErrInvalidUTF8}},
+		want: `json: cannot handle Go string within "/fizz/bar": invalid UTF-8 within "/foo/bar/baz" after offset 53`,
+	}, {
+		err:  &SemanticError{ByteOffset: 16, GoType: T[string](), Err: &jsontext.SyntacticError{JSONPointer: "/foo/bar/baz", ByteOffset: 53, Err: jsonwire.ErrInvalidUTF8}},
+		want: `json: cannot handle Go string: invalid UTF-8 within "/foo/bar/baz" after offset 53`,
+	}, {
+		err:  &SemanticError{ByteOffset: 85, GoType: T[string](), Err: &jsontext.SyntacticError{JSONPointer: "/foo/bar/baz", ByteOffset: 53, Err: jsonwire.ErrInvalidUTF8}},
+		want: `json: cannot handle Go string after offset 85: invalid UTF-8 within "/foo/bar/baz" after offset 53`,
 	}}
 
 	for _, tt := range tests {

--- a/example_test.go
+++ b/example_test.go
@@ -371,8 +371,9 @@ func Example_unknownMembers() {
 	// Specifying RejectUnknownMembers causes Unmarshal
 	// to reject the presence of any unknown members.
 	err = json.Unmarshal([]byte(input), new(Color), json.RejectUnknownMembers(true))
-	if err != nil {
-		fmt.Println("Unmarshal error:", errors.Unwrap(err))
+	var serr *json.SemanticError
+	if errors.As(err, &serr) && serr.Err == json.ErrUnknownName {
+		fmt.Println("Unmarshal error:", serr.Err, strconv.Quote(serr.JSONPointer.LastToken()))
 	}
 
 	// By default, Marshal preserves unknown members stored in
@@ -393,7 +394,7 @@ func Example_unknownMembers() {
 
 	// Output:
 	// Unknown members: {"WebSafe":false}
-	// Unmarshal error: unknown name "WebSafe"
+	// Unmarshal error: unknown object member name "WebSafe"
 	// Output with unknown members:    {"Name":"Teal","Value":"#008080","WebSafe":false}
 	// Output without unknown members: {"Name":"Teal","Value":"#008080"}
 }

--- a/fields.go
+++ b/fields.go
@@ -49,6 +49,8 @@ type structField struct {
 	fieldOptions
 }
 
+var errNoExportedFields = errors.New("Go struct has no exported fields")
+
 func makeStructFields(root reflect.Type) (structFields, *SemanticError) {
 	// Setup a queue for a breath-first search.
 	var queueIndex int
@@ -221,8 +223,7 @@ func makeStructFields(root reflect.Type) (structFields, *SemanticError) {
 		// errors returned by errors.New would fail to serialize.
 		isEmptyStruct := t.NumField() == 0
 		if !isEmptyStruct && !hasAnyJSONTag && !hasAnyJSONField {
-			err := errors.New("Go struct has no exported fields")
-			return structFields{}, &SemanticError{GoType: t, Err: err}
+			return structFields{}, &SemanticError{GoType: t, Err: errNoExportedFields}
 		}
 	}
 

--- a/fields_test.go
+++ b/fields_test.go
@@ -197,7 +197,7 @@ func TestMakeStructFields(t *testing.T) {
 			X map[string]jsontext.Value `json:",unknown"`
 		}{},
 		want: structFields{
-			inlinedFallback: &structField{id: 0, index: []int{2}, typ: reflect.TypeFor[map[string]jsontext.Value](), fieldOptions: fieldOptions{name: "X", quotedName: `"X"`, unknown: true}},
+			inlinedFallback: &structField{id: 0, index: []int{2}, typ: T[map[string]jsontext.Value](), fieldOptions: fieldOptions{name: "X", quotedName: `"X"`, unknown: true}},
 		},
 	}, {
 		name: jsontest.Name("InvalidUTF8"),

--- a/fold_test.go
+++ b/fold_test.go
@@ -120,7 +120,7 @@ func runUnmarshalUnknown(tb testing.TB) {
 		for i := range n {
 			fields = append(fields, reflect.StructField{
 				Name: fmt.Sprintf("Name%d", i),
-				Type: reflect.TypeFor[int](),
+				Type: T[int](),
 				Tag:  `json:",nocase"`,
 			})
 		}

--- a/jsontext/errors.go
+++ b/jsontext/errors.go
@@ -52,22 +52,16 @@ type SyntacticError struct {
 // an absolute offset using state.offsetAt.
 //
 // It takes a where that specify how the JSON pointer is derived.
-// If where is 0 and the next token is an object value,
-// then it the pointer implicitly upgraded to point at the next token.
 // If the underlying error is a [pointerSuffixError],
 // then the suffix is appended to the derived pointer.
 func wrapSyntacticError(state interface {
 	offsetAt(pos int) int64
-	needObjectValue() bool
 	AppendStackPointer(b []byte, where int) []byte
 }, err error, pos, where int) error {
 	if _, ok := err.(*ioError); err == io.EOF || ok {
 		return err
 	}
 	offset := state.offsetAt(pos)
-	if where == 0 && state.needObjectValue() {
-		where = +1
-	}
 	ptr := state.AppendStackPointer(nil, where)
 	if serr, ok := err.(*pointerSuffixError); ok {
 		ptr = serr.appendPointer(ptr)

--- a/jsontext/export.go
+++ b/jsontext/export.go
@@ -68,3 +68,8 @@ func (export) GetStreamingDecoder(r io.Reader, o ...Options) *Decoder {
 func (export) PutStreamingDecoder(d *Decoder) {
 	putStreamingDecoder(d)
 }
+
+func (export) IsIOError(err error) bool {
+	_, ok := err.(*ioError)
+	return ok
+}

--- a/jsontext/state_test.go
+++ b/jsontext/state_test.go
@@ -37,6 +37,19 @@ func TestPointer(t *testing.T) {
 			if got := tt.in.Parent().AppendToken(tt.in.LastToken()); got != tt.in {
 				t.Errorf("Pointer(%q).Parent().AppendToken(LastToken()) = %q, want %q", tt.in, got, tt.in)
 			}
+			in := tt.in
+			for {
+				if (in + "x").Contains(tt.in) {
+					t.Errorf("Pointer(%q).Contains(%q) = true, want false", in+"x", tt.in)
+				}
+				if !in.Contains(tt.in) {
+					t.Errorf("Pointer(%q).Contains(%q) = false, want true", in, tt.in)
+				}
+				if in == in.Parent() {
+					break
+				}
+				in = in.Parent()
+			}
 		}
 		if got := slices.Collect(tt.in.Tokens()); !slices.Equal(got, tt.wantTokens) {
 			t.Errorf("Pointer(%q).Tokens = %q, want %q", tt.in, got, tt.wantTokens)

--- a/jsontext/token.go
+++ b/jsontext/token.go
@@ -190,7 +190,7 @@ func (t Token) Clone() Token {
 		if uint64(raw.previousOffsetStart()) != t.num {
 			panic(invalidTokenPanic)
 		}
-		buf := bytes.Clone(raw.PreviousBuffer())
+		buf := bytes.Clone(raw.previousBuffer())
 		return Token{raw: &decodeBuffer{buf: buf, prevStart: 0, prevEnd: len(buf)}}
 	}
 	return t
@@ -214,7 +214,7 @@ func (t Token) Bool() bool {
 func (t Token) appendString(dst []byte, flags *jsonflags.Flags) ([]byte, error) {
 	if raw := t.raw; raw != nil {
 		// Handle raw string value.
-		buf := raw.PreviousBuffer()
+		buf := raw.previousBuffer()
 		if Kind(buf[0]) == '"' {
 			if jsonwire.ConsumeSimpleString(buf) == len(buf) {
 				return append(dst, buf...), nil
@@ -248,7 +248,7 @@ func (t Token) string() (string, []byte) {
 		if uint64(raw.previousOffsetStart()) != t.num {
 			panic(invalidTokenPanic)
 		}
-		buf := raw.PreviousBuffer()
+		buf := raw.previousBuffer()
 		if buf[0] == '"' {
 			// TODO: Preserve ValueFlags in Token?
 			isVerbatim := jsonwire.ConsumeSimpleString(buf) == len(buf)
@@ -279,7 +279,7 @@ func (t Token) string() (string, []byte) {
 func (t Token) appendNumber(dst []byte, canonicalize bool) ([]byte, error) {
 	if raw := t.raw; raw != nil {
 		// Handle raw number value.
-		buf := raw.PreviousBuffer()
+		buf := raw.previousBuffer()
 		if Kind(buf[0]).normalize() == '0' {
 			if !canonicalize {
 				return append(dst, buf...), nil
@@ -312,7 +312,7 @@ func (t Token) Float() float64 {
 		if uint64(raw.previousOffsetStart()) != t.num {
 			panic(invalidTokenPanic)
 		}
-		buf := raw.PreviousBuffer()
+		buf := raw.previousBuffer()
 		if Kind(buf[0]).normalize() == '0' {
 			fv, _ := jsonwire.ParseFloat(buf, 64)
 			return fv
@@ -356,7 +356,7 @@ func (t Token) Int() int64 {
 			panic(invalidTokenPanic)
 		}
 		neg := false
-		buf := raw.PreviousBuffer()
+		buf := raw.previousBuffer()
 		if len(buf) > 0 && buf[0] == '-' {
 			neg, buf = true, buf[1:]
 		}
@@ -417,7 +417,7 @@ func (t Token) Uint() uint64 {
 			panic(invalidTokenPanic)
 		}
 		neg := false
-		buf := raw.PreviousBuffer()
+		buf := raw.previousBuffer()
 		if len(buf) > 0 && buf[0] == '-' {
 			neg, buf = true, buf[1:]
 		}


### PR DESCRIPTION
Changes made:
* Always populate SemanticError.JSONPointer.
* Export ErrUnknownName to programmatically identify an unknown name.
* Reduce verbosity of SemanticError.Error method.
* Apply Hyrum-proofing on a per-process basis, rather than on a per-error.Error method call.
* Cleanup error wrapping for user-provided method and function calls. Some heuristics were used to provided reasonable position injection into user-provided errors.