### PR TITLE
Truncate JSON pointer when printing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -99,7 +99,7 @@ func (e *SemanticError) Error() string {
 	switch {
 	case e.JSONPointer != "":
 		sb.WriteString(" within JSON value at ")
-		sb.WriteString(strconv.Quote(string(e.JSONPointer)))
+		sb.WriteString(strconv.Quote(jsonwire.TruncatePointer(string(e.JSONPointer), 100)))
 	case e.ByteOffset > 0:
 		sb.WriteString(" after byte offset ")
 		sb.WriteString(strconv.FormatInt(e.ByteOffset, 10))

--- a/internal/jsonwire/wire_test.go
+++ b/internal/jsonwire/wire_test.go
@@ -73,3 +73,27 @@ func FuzzCompareUTF16(f *testing.F) {
 		}
 	})
 }
+
+func TestTruncatePointer(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"hello", "hello"},
+		{"/a/b/c", "/a/b/c"},
+		{"/a/b/c/d/e/f/g", "/a/b/…/f/g"},
+		{"supercalifragilisticexpialidocious", "super…cious"},
+		{"/supercalifragilisticexpialidocious/supercalifragilisticexpialidocious", "/supe…/…cious"},
+		{"/supercalifragilisticexpialidocious/supercalifragilisticexpialidocious/supercalifragilisticexpialidocious", "/supe…/…/…cious"},
+		{"/a/supercalifragilisticexpialidocious/supercalifragilisticexpialidocious", "/a/…/…cious"},
+		{"/supercalifragilisticexpialidocious/supercalifragilisticexpialidocious/b", "/supe…/…/b"},
+		{"/fizz/buzz/bazz", "/fizz/…/bazz"},
+		{"/fizz/buzz/bazz/razz", "/fizz/…/razz"},
+		{"/////////////////////////////", "/////…/////"},
+		{"/🎄❤️✨/🎁✅😊/🎅🔥⭐", "/🎄…/…/…⭐"},
+	}
+	for _, tt := range tests {
+		got := TruncatePointer(tt.in, 10)
+		if got != tt.want {
+			t.Errorf("TruncatePointer(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+}

--- a/jsontext/errors.go
+++ b/jsontext/errors.go
@@ -91,8 +91,7 @@ func (e *SyntacticError) Error() string {
 		b = append(b, "syntactic error"...)
 	}
 	if pointer != "" {
-		// TODO: Truncate excessively long pointers.
-		b = strconv.AppendQuote(append(b, " within "...), string(pointer))
+		b = strconv.AppendQuote(append(b, " within "...), jsonwire.TruncatePointer(string(pointer), 100))
 	}
 	if offset > 0 {
 		b = strconv.AppendInt(append(b, " after offset "...), offset, 10)


### PR DESCRIPTION
For deeply nested JSON values, the printed JSON pointer could become excessively long for logging. Truncate the pointer and preserve the head and tail of the pointer.