### PR TITLE
Add encoding.TextAppender to forbidden inline types

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -121,7 +121,7 @@ func makeStructFields(root reflect.Type) (structFields, *SemanticError) {
 				// Reject any types with custom serialization otherwise
 				// it becomes impossible to know what sub-fields to inline.
 				if which := implementsWhich(tf,
-					jsonMarshalerV2Type, jsonMarshalerV1Type, textMarshalerType,
+					jsonMarshalerV2Type, jsonMarshalerV1Type, textAppenderType, textMarshalerType,
 					jsonUnmarshalerV2Type, jsonUnmarshalerV1Type, textUnmarshalerType,
 				); which != nil && tf != jsontextValueType {
 					err := fmt.Errorf("inlined Go struct field %s of type %s must not implement JSON marshal or unmarshal methods", sf.Name, tf)

--- a/fields_test.go
+++ b/fields_test.go
@@ -237,6 +237,12 @@ func TestMakeStructFields(t *testing.T) {
 		}{},
 		wantErr: errors.New(`inlined Go struct field A of type struct { encoding.TextMarshaler } must not implement JSON marshal or unmarshal methods`),
 	}, {
+		name: jsontest.Name("InlineTextAppender"),
+		in: struct {
+			A struct{ encodingTextAppender } `json:",inline"`
+		}{},
+		wantErr: errors.New(`inlined Go struct field A of type struct { json.encodingTextAppender } must not implement JSON marshal or unmarshal methods`),
+	}, {
 		name: jsontest.Name("UnknownJSONMarshalerV1"),
 		in: struct {
 			A struct{ MarshalerV1 } `json:",unknown"`


### PR DESCRIPTION
An inlined type cannot support any of the interfaces with user-defined behavior, otherwise, it is impossible to derive the set of fields handled by the type.

Add the new encoding.TextAppender type to the list.