### PR TITLE
Support named strings as inlined map keys

### DIFF
--- a/arshal_inlined.go
+++ b/arshal_inlined.go
@@ -103,12 +103,12 @@ func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *j
 		}
 		return nil
 	} else {
-		m := v // must be a map[string]V
+		m := v // must be a map[~string]V
 		n := m.Len()
 		if n == 0 {
 			return nil
 		}
-		mk := newAddressableValue(stringType)
+		mk := newAddressableValue(m.Type().Key())
 		mv := newAddressableValue(m.Type().Elem())
 		marshalKey := func(mk addressableValue) error {
 			xe := export.Encoder(enc)
@@ -202,12 +202,15 @@ func unmarshalInlinedFallbackNext(dec *jsontext.Decoder, va addressableValue, uo
 	} else {
 		name := string(unquotedName) // TODO: Intern this?
 
-		m := v // must be a map[string]V
+		m := v // must be a map[~string]V
 		if m.IsNil() {
 			m.Set(reflect.MakeMap(m.Type()))
 		}
 		mk := reflect.ValueOf(name)
-		mv := newAddressableValue(v.Type().Elem()) // TODO: Cache across calls?
+		if mkt := m.Type().Key(); mkt != stringType {
+			mk = mk.Convert(mkt)
+		}
+		mv := newAddressableValue(m.Type().Elem()) // TODO: Cache across calls?
 		if v2 := m.MapIndex(mk); v2.IsValid() {
 			mv.Set(v2)
 		}

--- a/doc.go
+++ b/doc.go
@@ -107,9 +107,9 @@
 //     A Go embedded field is implicitly inlined unless an explicit JSON name
 //     is specified. The inlined field must be a Go struct
 //     (that does not implement any JSON methods), [jsontext.Value],
-//     map[string]T, or an unnamed pointer to such types. When marshaling,
+//     map[~string]T, or an unnamed pointer to such types. When marshaling,
 //     inlined fields from a pointer type are omitted if it is nil.
-//     Inlined fields of type [jsontext.Value] and map[string]T are called
+//     Inlined fields of type [jsontext.Value] and map[~string]T are called
 //     “inlined fallbacks” as they can represent all possible
 //     JSON object members not directly handled by the parent struct.
 //     Only one inlined fallback field may be specified in a struct,
@@ -119,7 +119,7 @@
 //   - unknown: The "unknown" option is a specialized variant
 //     of the inlined fallback to indicate that this Go struct field
 //     contains any number of unknown JSON object members. The field type must
-//     be a [jsontext.Value], map[string]T, or an unnamed pointer to such types.
+//     be a [jsontext.Value], map[~string]T, or an unnamed pointer to such types.
 //     If [DiscardUnknownMembers] is specified when marshaling,
 //     the contents of this field are ignored.
 //     If [RejectUnknownMembers] is specified when unmarshaling,

--- a/fields_test.go
+++ b/fields_test.go
@@ -304,11 +304,17 @@ func TestMakeStructFields(t *testing.T) {
 		}{},
 		wantErr: errors.New(`inlined Go struct field A of type map[int]interface {} must be a Go struct, Go map of string key, or jsontext.Value`),
 	}, {
-		name: jsontest.Name("InlineUnsupported/MapNamedStringKey"),
+		name: jsontest.Name("InlineUnsupported/MapTextMarshalerStringKey"),
 		in: struct {
-			A map[namedString]any `json:",inline"`
+			A map[nocaseString]any `json:",inline"`
 		}{},
-		wantErr: errors.New(`inlined Go struct field A of type map[json.namedString]interface {} must be a Go struct, Go map of string key, or jsontext.Value`),
+		wantErr: errors.New(`inlined map field A of type map[json.nocaseString]interface {} must have a string key that does not implement marshal or unmarshal methods`),
+	}, {
+		name: jsontest.Name("InlineUnsupported/MapMarshalerV1StringKey"),
+		in: struct {
+			A map[stringMarshalEmpty]any `json:",inline"`
+		}{},
+		wantErr: errors.New(`inlined map field A of type map[json.stringMarshalEmpty]interface {} must have a string key that does not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("InlineUnsupported/DoublePointer"),
 		in: struct {


### PR DESCRIPTION
It should be possible to support map[~string]T as an inlined fallback so long as the string type does not implement marshal/unmarshal methods.