### PR TITLE
Implement legacy semantics for merging

### DIFF
--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -266,6 +266,12 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			if err != nil {
 				return err // must be a syntactic or I/O error
 			}
+			if val.Kind() == 'n' {
+				if !uo.Flags.Get(jsonflags.MergeWithLegacySemantics) {
+					va.SetZero()
+				}
+				return nil
+			}
 			if val.Kind() != '"' {
 				return newUnmarshalErrorAfter(dec, t, errNonStringValue)
 			}

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -7736,6 +7736,13 @@ func TestUnmarshal(t *testing.T) {
 		inVal: new(struct{ X *onlyMethodText }),
 		want:  addr(struct{ X *onlyMethodText }{X: &onlyMethodText{allMethods: allMethods{method: "UnmarshalText", value: []byte(`hello`)}}}),
 	}, {
+		name:  jsontest.Name("Methods/Text/Null"),
+		inBuf: `{"X":null}`,
+		inVal: addr(struct{ X unmarshalTextFunc }{unmarshalTextFunc(func(b []byte) error {
+			return errMustNotCall
+		})}),
+		want: addr(struct{ X unmarshalTextFunc }{nil}),
+	}, {
 		name:  jsontest.Name("Methods/IP"),
 		inBuf: `"192.168.0.100"`,
 		inVal: new(net.IP),

--- a/arshal_time.go
+++ b/arshal_time.go
@@ -82,7 +82,9 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			}
 			switch k := val.Kind(); k {
 			case 'n':
-				*td = time.Duration(0)
+				if !uo.Flags.Get(jsonflags.MergeWithLegacySemantics) {
+					*td = time.Duration(0)
+				}
 				return nil
 			case '"':
 				if u.isNumeric() && !uo.Flags.Get(jsonflags.StringifyNumbers) {
@@ -145,7 +147,9 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			}
 			switch k := val.Kind(); k {
 			case 'n':
-				*tt = time.Time{}
+				if !uo.Flags.Get(jsonflags.MergeWithLegacySemantics) {
+					*tt = time.Time{}
+				}
 				return nil
 			case '"':
 				if u.isNumeric() && !uo.Flags.Get(jsonflags.StringifyNumbers) {

--- a/v1/decode.go
+++ b/v1/decode.go
@@ -223,7 +223,9 @@ func (n *Number) UnmarshalJSONV2(dec *jsontext.Decoder, opts jsonv2.Options) err
 	k := val.Kind()
 	switch k {
 	case 'n':
-		*n = "" // TODO: Should we merge with legacy semantics?
+		if legacy, _ := jsonv2.GetOption(opts, MergeWithLegacySemantics); !legacy {
+			*n = ""
+		}
 		return nil
 	case '"':
 		if !stringify {

--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -1805,19 +1805,8 @@ func TestNullString(t *testing.T) {
 	}
 }
 
-func intp(x int) *int {
-	p := new(int)
-	*p = x
-	return p
-}
-
-func intpp(x *int) **int {
-	pp := new(*int)
-	*pp = x
-	return pp
-}
-
 func TestInterfaceSet(t *testing.T) {
+	errUnmarshal := &UnmarshalTypeError{Value: "object", Offset: 5, Type: reflect.TypeFor[int](), Field: "X"}
 	tests := []struct {
 		CaseName
 		pre  any
@@ -1828,22 +1817,55 @@ func TestInterfaceSet(t *testing.T) {
 		{Name(""), "foo", `2`, 2.0},
 		{Name(""), "foo", `true`, true},
 		{Name(""), "foo", `null`, nil},
+		{Name(""), map[string]any{}, `true`, true},
+		{Name(""), []string{}, `true`, true},
 
-		{Name(""), nil, `null`, nil},
-		{Name(""), new(int), `null`, nil},
-		{Name(""), (*int)(nil), `null`, nil},
-		{Name(""), new(*int), `null`, new(*int)},
-		{Name(""), (**int)(nil), `null`, nil},
-		{Name(""), intp(1), `null`, nil},
-		{Name(""), intpp(nil), `null`, intpp(nil)},
-		{Name(""), intpp(intp(1)), `null`, intpp(nil)},
+		{Name(""), any(nil), `null`, any(nil)},
+		{Name(""), (*int)(nil), `null`, any(nil)},
+		{Name(""), (*int)(addr(0)), `null`, any(nil)},
+		{Name(""), (*int)(addr(1)), `null`, any(nil)},
+		{Name(""), (**int)(nil), `null`, any(nil)},
+		{Name(""), (**int)(addr[*int](nil)), `null`, (**int)(addr[*int](nil))},
+		{Name(""), (**int)(addr(addr(1))), `null`, (**int)(addr[*int](nil))},
+		{Name(""), (***int)(nil), `null`, any(nil)},
+		{Name(""), (***int)(addr[**int](nil)), `null`, (***int)(addr[**int](nil))},
+		{Name(""), (***int)(addr(addr[*int](nil))), `null`, (***int)(addr[**int](nil))},
+		{Name(""), (***int)(addr(addr(addr(1)))), `null`, (***int)(addr[**int](nil))},
+
+		{Name(""), any(nil), `2`, float64(2)},
+		{Name(""), (int)(1), `2`, float64(2)},
+		{Name(""), (*int)(nil), `2`, float64(2)},
+		{Name(""), (*int)(addr(0)), `2`, (*int)(addr(2))},
+		{Name(""), (*int)(addr(1)), `2`, (*int)(addr(2))},
+		{Name(""), (**int)(nil), `2`, float64(2)},
+		{Name(""), (**int)(addr[*int](nil)), `2`, (**int)(addr(addr(2)))},
+		{Name(""), (**int)(addr(addr(1))), `2`, (**int)(addr(addr(2)))},
+		{Name(""), (***int)(nil), `2`, float64(2)},
+		{Name(""), (***int)(addr[**int](nil)), `2`, (***int)(addr(addr(addr(2))))},
+		{Name(""), (***int)(addr(addr[*int](nil))), `2`, (***int)(addr(addr(addr(2))))},
+		{Name(""), (***int)(addr(addr(addr(1)))), `2`, (***int)(addr(addr(addr(2))))},
+
+		{Name(""), any(nil), `{}`, map[string]any{}},
+		{Name(""), (int)(1), `{}`, map[string]any{}},
+		{Name(""), (*int)(nil), `{}`, map[string]any{}},
+		{Name(""), (*int)(addr(0)), `{}`, errUnmarshal},
+		{Name(""), (*int)(addr(1)), `{}`, errUnmarshal},
+		{Name(""), (**int)(nil), `{}`, map[string]any{}},
+		{Name(""), (**int)(addr[*int](nil)), `{}`, errUnmarshal},
+		{Name(""), (**int)(addr(addr(1))), `{}`, errUnmarshal},
+		{Name(""), (***int)(nil), `{}`, map[string]any{}},
+		{Name(""), (***int)(addr[**int](nil)), `{}`, errUnmarshal},
+		{Name(""), (***int)(addr(addr[*int](nil))), `{}`, errUnmarshal},
+		{Name(""), (***int)(addr(addr(addr(1)))), `{}`, errUnmarshal},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			skipKnownFailure(t)
 			b := struct{ X any }{tt.pre}
 			blob := `{"X":` + tt.json + `}`
 			if err := Unmarshal([]byte(blob), &b); err != nil {
+				if wantErr, _ := tt.post.(error); equalError(err, wantErr) {
+					return
+				}
 				t.Fatalf("%s: Unmarshal(%#q) error: %v", tt.Where, blob, err)
 			}
 			if !reflect.DeepEqual(b.X, tt.post) {

--- a/v1/failing.txt
+++ b/v1/failing.txt
@@ -5,17 +5,6 @@ TestUnmarshal/#109
 TestUnmarshal/#111
 TestUnmarshal/#113
 TestUnmarshal/#138
-TestNullString
-TestInterfaceSet
-TestInterfaceSet/#01
-TestInterfaceSet/#02
-TestInterfaceSet/#07
-TestInterfaceSet/#10
-TestInterfaceSet/#11
-TestUnmarshalNulls
-TestPrefilled
-TestPrefilled/#00
-TestPrefilled/#01
 TestEncodeRenamedByteSlice
 TestNilMarshal
 TestNilMarshal/#08
@@ -26,8 +15,3 @@ TestStringOption/Unmarshal/Null/v1
 TestStringOption/Unmarshal/Deep/v1
 TestPointerReceiver
 TestPointerReceiver/Marshal/v1
-TestPointerReceiver/Unmarshal/v1
-TestMergeNull
-TestMergeNull/Unmarshal/v1
-TestMergeComposite
-TestMergeComposite/Unmarshal/v1

--- a/v1/options.go
+++ b/v1/options.go
@@ -38,6 +38,7 @@ type Options = jsonopts.Options
 //   - [FormatTimeDurationAsNanosecond]
 //   - [IgnoreStructErrors]
 //   - [MatchCaseSensitiveDelimiter]
+//   - [MergeWithLegacySemantics]
 //   - [OmitEmptyWithLegacyDefinition]
 //   - [PreserveRawStrings]
 //   - [RejectFloatOverflow]
@@ -144,6 +145,35 @@ func MatchCaseSensitiveDelimiter(v bool) Options {
 		return jsonflags.MatchCaseSensitiveDelimiter | 1
 	} else {
 		return jsonflags.MatchCaseSensitiveDelimiter | 0
+	}
+}
+
+// MergeWithLegacySemantics specifies that unmarshaling into a non-zero
+// Go value follows legacy semantics.
+//
+// When unmarshaling a JSON null, this preserves the original Go value
+// if the kind is a bool, int, uint, float, string, array, or struct.
+// Otherwise, it zeros the Go value.
+// This differs from the v2 semantic, which consistently and always
+// zeros the Go value when unmarshaling a JSON null into it.
+//
+// When unmarshaling a JSON value other than null, this merges into
+// the original Go value for array elements, slice elements,
+// struct fields (but not map values),
+// pointer values, and interface values (only if a non-nil pointer).
+// This differs from the v2 semantic, which merges into the original
+// Go value for struct fields, map values,
+// pointer values, and interface values.
+// In general, the v2 semantic merges when unmarshaling a JSON object,
+// otherwise it replaces the original value.
+//
+// This only affects unmarshaling and is ignored when marshaling.
+// The v1 default is true.
+func MergeWithLegacySemantics(v bool) Options {
+	if v {
+		return jsonflags.MergeWithLegacySemantics | 1
+	} else {
+		return jsonflags.MergeWithLegacySemantics | 0
 	}
 }
 


### PR DESCRIPTION
This includes a minor v2 change where it is valid to unmarshal a JSON null into an encoding.TextMarshaler.

TestInterfaceSet was modernized and had more test cases added. The behavior that it enforces is identical to what v1 does today. This test change has been upstreamed as https://go.dev/cl/638256.