### PR TITLE
Fix duplicate name check with maps under legacy merging

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -928,14 +928,17 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 					return newUnmarshalErrorAfter(dec, t, err)
 				}
 
-				v2 := va.MapIndex(k.Value)
-				if v2.IsValid() && !uo.Flags.Get(jsonflags.MergeWithLegacySemantics) {
+				if v2 := va.MapIndex(k.Value); v2.IsValid() {
 					if !xd.Flags.Get(jsonflags.AllowDuplicateNames) && (!seen.IsValid() || seen.MapIndex(k.Value).IsValid()) {
 						// TODO: Unread the object name.
 						name := xd.PreviousTokenOrValue()
 						return newDuplicateNameError(dec.StackPointer(), nil, dec.InputOffset()-len64(name))
 					}
-					v.Set(v2)
+					if !uo.Flags.Get(jsonflags.MergeWithLegacySemantics) {
+						v.Set(v2)
+					} else {
+						v.SetZero()
+					}
 				} else {
 					v.SetZero()
 				}

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -5595,6 +5595,13 @@ func TestUnmarshal(t *testing.T) {
 		want:    addr(map[int]int{0: 1}),
 		wantErr: newDuplicateNameError("", []byte(`"-0"`), len64(`{"0":1,`)),
 	}, {
+		name:    jsontest.Name("Maps/DuplicateName/Int/MergeWithLegacySemantics"),
+		opts:    []Options{jsonflags.MergeWithLegacySemantics | 1},
+		inBuf:   `{"0":1,"-0":-1}`,
+		inVal:   new(map[int]int),
+		want:    addr(map[int]int{0: 1}),
+		wantErr: newDuplicateNameError("", []byte(`"-0"`), len64(`{"0":1,`)),
+	}, {
 		name:  jsontest.Name("Maps/DuplicateName/Int/AllowDuplicateNames"),
 		opts:  []Options{jsontext.AllowDuplicateNames(true)},
 		inBuf: `{"0":1,"-0":-1}`,


### PR DESCRIPTION
In PR #84, the logic accidentally stopped performing the duplicate name check under the legacy merge semantics, when these are orthogonal concerns.

Push the check down into the body if v2.IsValid.