### PR TITLE
Remove TestUnmarshalRecursivePointer

### DIFF
--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -2539,19 +2539,6 @@ func TestUnmarshalPanic(t *testing.T) {
 	t.Fatalf("Unmarshal should have panicked")
 }
 
-// The decoder used to hang if decoding into an interface pointing to its own address.
-// See golang.org/issues/31740.
-func TestUnmarshalRecursivePointer(t *testing.T) {
-	t.Skip("TODO: implement cycle detection in v2?")
-	var v any
-	v = &v
-	data := []byte(`{"a": "b"}`)
-
-	if err := Unmarshal(data, v); err != nil {
-		t.Fatalf("Unmarshal error: %v", err)
-	}
-}
-
 type textUnmarshalerString string
 
 func (m *textUnmarshalerString) UnmarshalText(text []byte) error {


### PR DESCRIPTION
In v1, a special-case check was added for when an interface value contained a pointer to itself, which would lead to an infinite cycle trying to following the sequence until it found a non-interface or non-pointer value.

In particular, it would detect this pattern:

	var v any
	v = &v
	json.Unmarshal(..., v)

However, this does not detect the general problem. Thus, v1 would still run into an infinite cycle with:

	var v any
	v1 := &v
	v = &v1
	json.Unmarshal(..., v)

where there are 2 layers of pointers, still leading to a cycle.

We should either detect the general case or
not try to detect cycles at all.

Fundamentally, it is difficult to detect the general case without either O(N) memory or doing something clever like Floyd's cycle finding algorithm. Both approaches are expensive for the questionable value that this check brings.

It is also questionable why infinite cycles through pointers and interfaces should be specially handled when the "json" package does not detect other forms of infinite cycles such as infinite recursion through an UnmarshalJSON method.

These situations are all indicative of a programmer mistake. While presenting an error would be ideal,
we lack an efficient way to detect this.

Updates golang/go#31740