### PR TITLE
Implement legacy support for binary data encoding

### DIFF
--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -33,10 +33,9 @@ var (
 	// There is no semantic difference with this change.
 	appenderToType = reflect.TypeFor[interface{ AppendTo([]byte) []byte }]()
 
-	allMethodTypes = []reflect.Type{
-		jsonMarshalerV2Type, jsonMarshalerV1Type, textAppenderType, textMarshalerType,
-		jsonUnmarshalerV2Type, jsonUnmarshalerV1Type, textUnmarshalerType,
-	}
+	allMarshalerTypes   = []reflect.Type{jsonMarshalerV2Type, jsonMarshalerV1Type, textAppenderType, textMarshalerType}
+	allUnmarshalerTypes = []reflect.Type{jsonUnmarshalerV2Type, jsonUnmarshalerV1Type, textUnmarshalerType}
+	allMethodTypes      = append(allMarshalerTypes, allUnmarshalerTypes...)
 )
 
 // TODO(https://go.dev/issue/62384): Use encoding.TextAppender instead

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -2139,7 +2139,7 @@ func TestMarshal(t *testing.T) {
 	"Default": "AQIDBA=="
 }`}, {
 		name: jsontest.Name("Structs/Format/ArrayBytes/Legacy"),
-		opts: []Options{jsontext.Multiline(true), jsonflags.FormatByteArrayAsArray | 1},
+		opts: []Options{jsontext.Multiline(true), jsonflags.FormatBytesWithLegacySemantics | 1},
 		in: structFormatArrayBytes{
 			Base16:    [4]byte{1, 2, 3, 4},
 			Base32:    [4]byte{1, 2, 3, 4},
@@ -6204,7 +6204,7 @@ func TestUnmarshal(t *testing.T) {
 		}),
 	}, {
 		name: jsontest.Name("Structs/Format/ArrayBytes/Legacy"),
-		opts: []Options{jsonflags.FormatByteArrayAsArray | 1},
+		opts: []Options{jsonflags.FormatBytesWithLegacySemantics | 1},
 		inBuf: `{
 	"Base16": "01020304",
 	"Base32": "AEBAGBA=",

--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -56,7 +56,7 @@ const (
 		FormatNilMapAsNull |
 		FormatNilSliceAsNull |
 		MatchCaseInsensitiveNames |
-		FormatByteArrayAsArray |
+		FormatBytesWithLegacySemantics |
 		FormatTimeDurationAsNanosecond |
 		IgnoreStructErrors |
 		MatchCaseSensitiveDelimiter |
@@ -123,7 +123,7 @@ const (
 const (
 	_ Bools = (maxArshalV2Flag >> 1) << iota
 
-	FormatByteArrayAsArray         // marshal or unmarshal
+	FormatBytesWithLegacySemantics // marshal or unmarshal
 	FormatTimeDurationAsNanosecond // marshal or unmarshal
 	IgnoreStructErrors             // marshal or unmarshal
 	MatchCaseSensitiveDelimiter    // marshal or unmarshal

--- a/v1/failing.txt
+++ b/v1/failing.txt
@@ -1,10 +1,5 @@
 TestUnmarshal
 TestUnmarshal/#106
-TestUnmarshal/#107
-TestUnmarshal/#109
-TestUnmarshal/#111
-TestUnmarshal/#113
-TestEncodeRenamedByteSlice
 TestNilMarshal
 TestNilMarshal/#08
 TestNilMarshal/#11

--- a/v1/options.go
+++ b/v1/options.go
@@ -34,7 +34,7 @@ type Options = jsonopts.Options
 // It is equivalent to the following boolean options being set to true:
 //
 //   - [EscapeInvalidUTF8]
-//   - [FormatByteArrayAsArray]
+//   - [FormatBytesWithLegacySemantics]
 //   - [FormatTimeDurationAsNanosecond]
 //   - [IgnoreStructErrors]
 //   - [MatchCaseSensitiveDelimiter]
@@ -83,19 +83,34 @@ func EscapeInvalidUTF8(v bool) Options {
 	}
 }
 
-// FormatByteArrayAsArray specifies that a [N]byte array is formatted
-// by default as a JSON array of byte values in contrast to v2 default
-// of using a JSON string with the base64 encoding of the value.
-// If a [N]byte field has a `format` tag option,
-// then the specified formatting takes precedence.
+// FormatBytesWithLegacySemantics specifies that handling of
+// []~byte and [N]~byte types follow legacy semantics:
+//
+//   - A Go [N]~byte is always treated as as a normal Go array
+//     in contrast to the v2 default of treating [N]byte as
+//     using some form of binary data encoding (RFC 4648).
+//
+//   - A Go []~byte is to be treated as using some form of
+//     binary data encoding (RFC 4648) in contrast to the v2 default
+//     of only treating []byte as such. In particular, v2 does not
+//     treat slices of named byte types as representing binary data.
+//
+//   - When marshaling, if a named byte implements a marshal method,
+//     then the slice is serialized as a JSON array of elements,
+//     each of which call the marshal method.
+//
+//   - When unmarshaling, if the input is a JSON array,
+//     then unmarshal into the []~byte as if it were a normal Go slice.
+//     In contrast, the v2 default is to report an error unmarshaling
+//     a JSON array when expecting some form of binary data encoding.
 //
 // This affects either marshaling or unmarshaling.
 // The v1 default is true.
-func FormatByteArrayAsArray(v bool) Options {
+func FormatBytesWithLegacySemantics(v bool) Options {
 	if v {
-		return jsonflags.FormatByteArrayAsArray | 1
+		return jsonflags.FormatBytesWithLegacySemantics | 1
 	} else {
-		return jsonflags.FormatByteArrayAsArray | 0
+		return jsonflags.FormatBytesWithLegacySemantics | 0
 	}
 }
 


### PR DESCRIPTION
WARNING: This commit includes breaking changes.

The FormatByteArrayAsArray option is renamed to
FormatBytesWithLegacySemantics with increased feature scope.

In v2, the behavior was altered for when a []~byte or [N]~byte is treated as using some form of binary data encoding (RFC 4648). Implement support for prior semantics.