### PR TITLE
Refactor method handling logic

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -302,7 +302,7 @@ func makeBytesArshaler(t reflect.Type, fncs *arshaler) *arshaler {
 	// to forcibly treat []namedByte as a []byte.
 	marshalArray := fncs.marshal
 	isNamedByte := t.Elem().PkgPath() != ""
-	hasMarshaler := implementsWhich(t.Elem(), allMarshalerTypes...) != nil
+	hasMarshaler := implementsAny(t.Elem(), allMarshalerTypes...)
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		if !mo.Flags.Get(jsonflags.FormatBytesWithLegacySemantics) && isNamedByte {
 			return marshalArray(enc, va, mo) // treat as []T or [N]T

--- a/fields.go
+++ b/fields.go
@@ -123,7 +123,7 @@ func makeStructFields(root reflect.Type) (sf structFields, serr *SemanticError) 
 				// Reject any types with custom serialization otherwise
 				// it becomes impossible to know what sub-fields to inline.
 				tf := indirectType(f.typ)
-				if implementsWhich(tf, allMethodTypes...) != nil && tf != jsontextValueType {
+				if implementsAny(tf, allMethodTypes...) && tf != jsontextValueType {
 					serr = orErrorf(serr, t, "inlined Go struct field %s of type %s must not implement marshal or unmarshal methods", sf.Name, tf)
 					continue // invalid inlined field; treat as ignored
 				}
@@ -151,7 +151,7 @@ func makeStructFields(root reflect.Type) (sf structFields, serr *SemanticError) 
 				case tf == jsontextValueType:
 					f.fncs = nil // specially handled in arshal_inlined.go
 				case tf.Kind() == reflect.Map && tf.Key().Kind() == reflect.String:
-					if implementsWhich(tf.Key(), allMethodTypes...) != nil {
+					if implementsAny(tf.Key(), allMethodTypes...) {
 						serr = orErrorf(serr, t, "inlined map field %s of type %s must have a string key that does not implement marshal or unmarshal methods", sf.Name, tf)
 						continue // invalid inlined field; treat as ignored
 					}
@@ -185,8 +185,8 @@ func makeStructFields(root reflect.Type) (sf structFields, serr *SemanticError) 
 					}
 					// Unfortunately, methods on the unexported field
 					// still cannot be called.
-					if implementsWhich(tf, allMethodTypes...) != nil ||
-						(f.omitzero && implementsWhich(tf, isZeroerType) != nil) {
+					if implementsAny(tf, allMethodTypes...) ||
+						(f.omitzero && implementsAny(tf, isZeroerType)) {
 						serr = orErrorf(serr, t, "Go struct field %s is not exported for method calls", sf.Name)
 						continue
 					}


### PR DESCRIPTION
The v2 semantics regarding methods has the consistent property that only one method is ever called for a particular Go type regardless of the calling context.
For example, if T implements both MarshalJSON and MarshalText, then MarshalJSON will always be used and it could very well be the case that MarshalText does not exist.
Unfortunately, v1 does not have this property where sometimes MarshalJSON is called, and othertimes MarshalText is called.

Method calling today is handled using logic like:

	switch which := implementsWhich(t, ti1, ti2, ti3); which {
	case ti1:
		v = ... // expr1
	case ti2:
		v = ... // expr2
	case ti3:
		v = ... // expr3
	}

where the highest precedence interface case is taken and all other interfaces are ignored (since they can no longer matter). This programming pattern makes it difficult to fall back on other interface methods when trying to implement v1 semantics.

Thus, we refactor the logic to look like:

	if implements(t, ti3) {
		v = ... // expr3
	}
	if implements(t, ti2) {
		v = ... // expr2
	}
	if implements(t, ti1) {
		v = ... // expr1
	}

In particular:

* In contrast to the prior switch-statement, interfaces are checked individually in the reverse order where the lowest precedence interface is checked first. Unfortunately, switching the order of evaluation means that the diff in this commit looks unreasonably large.

* If a higher precedence interface is applicable, it will override the prior marshal/unmarshal function (and thus be applicable with higher precedence). Note that every if-statement sets the same variable.

There are no behavorial changes in this commit.
In the code rewrite shown above, the ... expression is moved verbatim with no changes whatsoever.