### PR TITLE
Remove inaccurate documentation on Unmarshaler

### DIFF
--- a/v1/decode.go
+++ b/v1/decode.go
@@ -100,9 +100,6 @@ func Unmarshal(data []byte, v any) error {
 // The input can be assumed to be a valid encoding of
 // a JSON value. UnmarshalJSON must copy the JSON data
 // if it wishes to retain the data after returning.
-//
-// By convention, to approximate the behavior of [Unmarshal] itself,
-// Unmarshalers implement UnmarshalJSON([]byte("null")) as a no-op.
 type Unmarshaler = jsonv2.UnmarshalerV1
 
 // An UnmarshalTypeError describes a JSON value that was


### PR DESCRIPTION
It is not true that Unmarshal "conventionally" treats JSON nulls as a no-op. Rather it is inconsistent about whether it clears the value or is treated as a no-op.