### PR TITLE
Use arshal flags instead of coder flags

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -225,9 +225,8 @@ func marshalEncode(out *jsontext.Encoder, in any, mo *jsonopts.Struct) (err erro
 		marshal, _ = mo.Marshalers.(*Marshalers).lookup(marshal, t)
 	}
 	if err := marshal(out, va, mo); err != nil {
-		xe := export.Encoder(out)
-		if !xe.Flags.Get(jsonflags.AllowDuplicateNames) {
-			xe.Tokens.InvalidateDisabledNamespaces()
+		if !mo.Flags.Get(jsonflags.AllowDuplicateNames) {
+			export.Encoder(out).Tokens.InvalidateDisabledNamespaces()
 		}
 		return err
 	}
@@ -461,9 +460,8 @@ func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct) (err er
 		unmarshal, _ = uo.Unmarshalers.(*Unmarshalers).lookup(unmarshal, t)
 	}
 	if err := unmarshal(in, va, uo); err != nil {
-		xd := export.Decoder(in)
-		if !xd.Flags.Get(jsonflags.AllowDuplicateNames) {
-			xd.Tokens.InvalidateDisabledNamespaces()
+		if !uo.Flags.Get(jsonflags.AllowDuplicateNames) {
+			export.Decoder(in).Tokens.InvalidateDisabledNamespaces()
 		}
 		return err
 	}

--- a/arshal_any.go
+++ b/arshal_any.go
@@ -103,7 +103,7 @@ func marshalObjectAny(enc *jsontext.Encoder, obj map[string]any, mo *jsonopts.St
 			return enc.WriteToken(jsontext.Null)
 		}
 		// Optimize for marshaling an empty map without any preceding whitespace.
-		if !xe.Flags.Get(jsonflags.AnyWhitespace) && !xe.Tokens.Last.NeedObjectName() {
+		if !mo.Flags.Get(jsonflags.AnyWhitespace) && !xe.Tokens.Last.NeedObjectName() {
 			xe.Buf = append(xe.Tokens.MayAppendDelim(xe.Buf, '{'), "{}"...)
 			xe.Tokens.Last.Increment()
 			if xe.NeedFlush() {
@@ -118,7 +118,7 @@ func marshalObjectAny(enc *jsontext.Encoder, obj map[string]any, mo *jsonopts.St
 	}
 	// A Go map guarantees that each entry has a unique key
 	// The only possibility of duplicates is due to invalid UTF-8.
-	if !xe.Flags.Get(jsonflags.AllowInvalidUTF8) {
+	if !mo.Flags.Get(jsonflags.AllowInvalidUTF8) {
 		xe.Tokens.Last.DisableNamespace()
 	}
 	if !mo.Flags.Get(jsonflags.Deterministic) || len(obj) <= 1 {
@@ -168,7 +168,7 @@ func unmarshalObjectAny(dec *jsontext.Decoder, uo *jsonopts.Struct) (map[string]
 		obj := make(map[string]any)
 		// A Go map guarantees that each entry has a unique key
 		// The only possibility of duplicates is due to invalid UTF-8.
-		if !xd.Flags.Get(jsonflags.AllowInvalidUTF8) {
+		if !uo.Flags.Get(jsonflags.AllowInvalidUTF8) {
 			xd.Tokens.Last.DisableNamespace()
 		}
 		for dec.PeekKind() != '}' {
@@ -217,7 +217,7 @@ func marshalArrayAny(enc *jsontext.Encoder, arr []any, mo *jsonopts.Struct) erro
 			return enc.WriteToken(jsontext.Null)
 		}
 		// Optimize for marshaling an empty slice without any preceding whitespace.
-		if !xe.Flags.Get(jsonflags.AnyWhitespace) && !xe.Tokens.Last.NeedObjectName() {
+		if !mo.Flags.Get(jsonflags.AnyWhitespace) && !xe.Tokens.Last.NeedObjectName() {
 			xe.Buf = append(xe.Tokens.MayAppendDelim(xe.Buf, '['), "[]"...)
 			xe.Tokens.Last.Increment()
 			if xe.NeedFlush() {

--- a/arshal_funcs.go
+++ b/arshal_funcs.go
@@ -178,7 +178,7 @@ func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
 			val, err := fn(va.castTo(t).Interface().(T))
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal function of type func(T) ([]byte, error)")
-				if export.Encoder(enc).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if mo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFuncV1") // unlike unmarshal, always wrapped
 				}
 				err = newMarshalErrorBefore(enc, t, err)
@@ -230,7 +230,7 @@ func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshal
 					}
 					err = errSkipMutation
 				}
-				if xe.Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if mo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFuncV2") // unlike unmarshal, always wrapped
 				}
 				if !export.IsIOError(err) {
@@ -267,7 +267,7 @@ func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
 			err = fn(val, va.castTo(t).Interface().(T))
 			if err != nil {
 				err = wrapSkipFunc(err, "unmarshal function of type func([]byte, T) error")
-				if export.Decoder(dec).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if uo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return err // unlike marshal, never wrapped
 				}
 				err = newUnmarshalErrorAfter(dec, t, err)
@@ -312,7 +312,7 @@ func UnmarshalFuncV2[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmar
 					}
 					err = errSkipMutation
 				}
-				if export.Decoder(dec).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if uo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return err // unlike marshal, never wrapped
 				}
 				if !isSyntacticError(err) && !export.IsIOError(err) {

--- a/arshal_inlined.go
+++ b/arshal_inlined.go
@@ -111,8 +111,7 @@ func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *j
 		mk := newAddressableValue(m.Type().Key())
 		mv := newAddressableValue(m.Type().Elem())
 		marshalKey := func(mk addressableValue) error {
-			xe := export.Encoder(enc)
-			b, err := jsonwire.AppendQuote(enc.UnusedBuffer(), mk.String(), &xe.Flags)
+			b, err := jsonwire.AppendQuote(enc.UnusedBuffer(), mk.String(), &mo.Flags)
 			if err != nil {
 				return newMarshalErrorBefore(enc, m.Type().Key(), err)
 			}

--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -122,7 +122,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				return append(b, b2...), err
 			}); err != nil {
 				err = wrapSkipFunc(err, "marshal method")
-				if export.Encoder(enc).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if mo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalText") // unlike unmarshal, always wrapped
 				}
 				if !isSemanticError(err) && !export.IsIOError(err) {
@@ -155,7 +155,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			appender := va.Addr().Interface().(encodingTextAppender)
 			if err := export.Encoder(enc).AppendRaw('"', false, appender.AppendText); err != nil {
 				err = wrapSkipFunc(err, "append method")
-				if export.Encoder(enc).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if mo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return internal.NewMarshalerError(va.Addr().Interface(), err, "AppendText") // unlike unmarshal, always wrapped
 				}
 				if !isSemanticError(err) && !export.IsIOError(err) {
@@ -174,7 +174,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			val, err := marshaler.MarshalJSON()
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal method")
-				if export.Encoder(enc).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if mo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalJSON") // unlike unmarshal, always wrapped
 				}
 				err = newMarshalErrorBefore(enc, t, err)
@@ -204,7 +204,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			}
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal method")
-				if xe.Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if mo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalJSONV2") // unlike unmarshal, always wrapped
 				}
 				if !export.IsIOError(err) {
@@ -238,7 +238,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			unmarshaler := va.Addr().Interface().(encoding.TextUnmarshaler)
 			if err := unmarshaler.UnmarshalText(s); err != nil {
 				err = wrapSkipFunc(err, "unmarshal method")
-				if export.Decoder(dec).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if uo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return err // unlike marshal, never wrapped
 				}
 				if !isSemanticError(err) && !isSyntacticError(err) && !export.IsIOError(err) {
@@ -260,7 +260,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			unmarshaler := va.Addr().Interface().(UnmarshalerV1)
 			if err := unmarshaler.UnmarshalJSON(val); err != nil {
 				err = wrapSkipFunc(err, "unmarshal method")
-				if export.Decoder(dec).Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if uo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return err // unlike marshal, never wrapped
 				}
 				err = newUnmarshalErrorAfter(dec, t, err)
@@ -284,7 +284,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			}
 			if err != nil {
 				err = wrapSkipFunc(err, "unmarshal method")
-				if xd.Flags.Get(jsonflags.ReportLegacyErrorValues) {
+				if uo.Flags.Get(jsonflags.ReportLegacyErrorValues) {
 					return err // unlike marshal, never wrapped
 				}
 				if !isSyntacticError(err) && !export.IsIOError(err) {


### PR DESCRIPTION
Instead of consulting the flags on the coder via:

	export.Encoder(enc).Flags
	export.Decoder(dec).Flags

consult flags on the call-provided arshal options via:

	mo.Flags
	uo.Flags

This avoids unnecessarily peaking at the internals flags
of Encoder or Decoder and also allows us to simplify
some flag checking logic.

For example, the following are all equivalent:

	export.Encoder(enc).Flags.Get(Foo) || mo.Flags.Get(Bar)
	mo.Flags.Get(Foo) || mo.Flags.Get(Bar)
	mo.Flags.Get(Foo | Bar)

A similar transform can also be done by applying
De Morgan's law to the following:

	!export.Encoder(enc).Flags.Get(Foo) && !mo.Flags.Get(Bar)
	!mo.Flags.Get(Foo) && !mo.Flags.Get(Bar)
	!!(!mo.Flags.Get(Foo) && !mo.Flags.Get(Bar))
	!(mo.Flags.Get(Foo) || mo.Flags.Get(Bar))
	!(mo.Flags.Get(Foo | Bar))
	!mo.Flags.Get(Foo | Bar)

There should be no behavior changes as a result of this
since the arshal option flags should be an exact
superset of the coder option flags.

There are 6 entry points to the "json" package:
*	Marshal
*	MarshalWrite
*	MarshaEncode
*	Unmarshal
*	UnmarshalRead
*	UnmarshalDecode

4 of them (Marshal, MarshalWrite, Unmarshal, UnmarshalRead)
obtain a coder from an internal pool,
where the arshal options plumbed down the call stack
is a pointer to the one inside the coder.
Therefore, there is no behavior difference for these 4 calls.

2 of them (MarshalEncode, UnmarshalDecode) take in a
user-provided coder, where there could theoretically
be a difference between the options struct and the coder options.
However, in both functions, we obtain a jsonopts.Struct locally
from an internal pool and then call jsonopts.Struct.CopyCoderOptions
where the coder options are copied from the user-provided coder
into the local jsonopts.Struct. Thus, the options struct that
we plumb down the stack is gauranteed to be a superset of
the options in the user-provided coder.