### PR TITLE
Adjust tests for merging into stdlib

### DIFF
--- a/arshal_test.go
+++ b/arshal_test.go
@@ -132,9 +132,9 @@ type (
 		// cannot be called on an unexported field.
 		netipAddr `json:"name"`
 
-		// structMethodText has a MarshalText method
-		// that cancels out netipAddr.MarshalText.
-		structMethodText
+		// Bogus MarshalText and AppendText methods are declared on
+		// structUnexportedEmbeddedMethodTag to prevent it from
+		// implementing those method interfaces.
 	}
 	structUnexportedEmbeddedStruct struct {
 		structOmitZeroAll
@@ -572,6 +572,9 @@ type (
 		A *cyclicA `json:",inline"`
 	}
 )
+
+func (structUnexportedEmbeddedMethodTag) MarshalText() {}
+func (structUnexportedEmbeddedMethodTag) AppendText()  {}
 
 func (p *allMethods) MarshalJSONV2(enc *jsontext.Encoder, opts Options) error {
 	if got, want := "MarshalJSONV2", p.method; got != want {
@@ -9223,7 +9226,9 @@ func TestCoderBufferGrowth(t *testing.T) {
 		}
 	}
 
-	bb := &bytesBuffer{new(bytes.Buffer)}
+	// bb is identical to bytes.Buffer,
+	// but a different type to avoid any optimizations for bytes.Buffer.
+	bb := struct{ *bytes.Buffer }{new(bytes.Buffer)}
 
 	var writeSizes []int
 	if err := MarshalWrite(WriterFunc(func(b []byte) (int, error) {

--- a/fold_test.go
+++ b/fold_test.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"testing"
 	"unicode"
-
-	jsonv1 "encoding/json"
 )
 
 var equalFoldTestdata = []struct {
@@ -103,18 +101,10 @@ func TestFoldRune(t *testing.T) {
 // TestBenchmarkUnmarshalUnknown unmarshals an unknown field into a struct with
 // varying number of fields. Since the unknown field does not directly match
 // any known field by name, it must fall back on case-insensitive matching.
-func TestBenchmarkUnmarshalUnknown(t *testing.T) { runUnmarshalUnknown(t) }
-func BenchmarkUnmarshalUnknown(b *testing.B)     { runUnmarshalUnknown(b) }
-
-func runUnmarshalUnknown(tb testing.TB) {
+func TestBenchmarkUnmarshalUnknown(t *testing.T) {
 	in := []byte(`{"NameUnknown":null}`)
 	for _, n := range []int{1, 2, 5, 10, 20, 50, 100} {
 		unmarshal := Unmarshal
-		if benchV1 {
-			unmarshal = func(in []byte, out any, opts ...Options) error {
-				return jsonv1.Unmarshal(in, out)
-			}
-		}
 
 		var fields []reflect.StructField
 		for i := range n {
@@ -126,9 +116,9 @@ func runUnmarshalUnknown(tb testing.TB) {
 		}
 		out := reflect.New(reflect.StructOf(fields)).Interface()
 
-		runTestOrBench(tb, fmt.Sprintf("N%d", n), len64(in), func(tb testing.TB) {
+		t.Run(fmt.Sprintf("N%d", n), func(t *testing.T) {
 			if err := unmarshal(in, out); err != nil {
-				tb.Fatalf("Unmarshal error: %v", err)
+				t.Fatalf("Unmarshal error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
Adjust the tests to assist in merging this into the stdlib. In particular:
* In bench_test.go, switch from package json to json_test.
* In structUnexportedEmbeddedMethodTag, embed encodingTextAppender since netip.Addr now supports the AppendText method.