### PR TITLE
Avoid strict RFC 3339 checks for time.Time

### DIFF
--- a/arshal_test.go
+++ b/arshal_test.go
@@ -4387,7 +4387,7 @@ func TestMarshal(t *testing.T) {
 }`,
 	}, {
 		name: jsontest.Name("Duration/Format/Legacy"),
-		opts: []Options{jsonflags.FormatTimeDurationAsNanosecond | 1},
+		opts: []Options{jsonflags.FormatTimeWithLegacySemantics | 1},
 		in: structDurationFormat{
 			D1: 12*time.Hour + 34*time.Minute + 56*time.Second + 78*time.Millisecond + 90*time.Microsecond + 12*time.Nanosecond,
 			D2: 12*time.Hour + 34*time.Minute + 56*time.Second + 78*time.Millisecond + 90*time.Microsecond + 12*time.Nanosecond,
@@ -8850,7 +8850,7 @@ func TestUnmarshal(t *testing.T) {
 	}, {
 		name:  jsontest.Name("Duration/Format/Legacy"),
 		inBuf: `{"D1":45296078090012,"D2":"12h34m56.078090012s"}`,
-		opts:  []Options{jsonflags.FormatTimeDurationAsNanosecond | 1},
+		opts:  []Options{jsonflags.FormatTimeWithLegacySemantics | 1},
 		inVal: new(structDurationFormat),
 		want: addr(structDurationFormat{
 			D1: 12*time.Hour + 34*time.Minute + 56*time.Second + 78*time.Millisecond + 90*time.Microsecond + 12*time.Nanosecond,

--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -58,7 +58,7 @@ const (
 		MatchCaseInsensitiveNames |
 		CallMethodsWithLegacySemantics |
 		FormatBytesWithLegacySemantics |
-		FormatTimeDurationAsNanosecond |
+		FormatTimeWithLegacySemantics |
 		IgnoreStructErrors |
 		MatchCaseSensitiveDelimiter |
 		MergeWithLegacySemantics |
@@ -125,7 +125,7 @@ const (
 
 	CallMethodsWithLegacySemantics // marshal or unmarshal
 	FormatBytesWithLegacySemantics // marshal or unmarshal
-	FormatTimeDurationAsNanosecond // marshal or unmarshal
+	FormatTimeWithLegacySemantics  // marshal or unmarshal
 	IgnoreStructErrors             // marshal or unmarshal
 	MatchCaseSensitiveDelimiter    // marshal or unmarshal
 	MergeWithLegacySemantics       // unmarshal

--- a/v1/options.go
+++ b/v1/options.go
@@ -39,7 +39,7 @@ type Options = jsonopts.Options
 //   - [CallMethodsWithLegacySemantics]
 //   - [EscapeInvalidUTF8]
 //   - [FormatBytesWithLegacySemantics]
-//   - [FormatTimeDurationAsNanosecond]
+//   - [FormatTimeWithLegacySemantics]
 //   - [IgnoreStructErrors]
 //   - [MatchCaseSensitiveDelimiter]
 //   - [MergeWithLegacySemantics]
@@ -167,20 +167,29 @@ func FormatBytesWithLegacySemantics(v bool) Options {
 	}
 }
 
-// FormatTimeDurationAsNanosecond specifies that [time.Duration] is formatted
-// by default as a JSON number representing the number of nanoseconds
-// in contrast to the v2 default of using a JSON string with the duration
-// formatted with [time.Duration.String].
-// If a duration field has a `format` tag option,
-// then the specified formatting takes precedence.
+// FormatTimeWithLegacySemantics specifies that [time] types are formatted
+// with legacy semantics:
+//
+//   - When marshaling or unmarshaling, a [time.Duration] is formatted as
+//     a JSON number representing the number of nanoseconds.
+//     In contrast, the default v2 behavior uses a JSON string
+//     with the duration formatted with [time.Duration.String].
+//     If a duration field has a `format` tag option,
+//     then the specified formatting takes precedence.
+//
+//   - When unmarshaling, a [time.Time] follows loose adherence to RFC 3339.
+//     In particular, it permits historically incorrect representations,
+//     allowing for deviations in hour format, sub-second separator,
+//     and timezone representation. In contrast, the default v2 behavior
+//     is to strictly comply with the grammar specified in RFC 3339.
 //
 // This affects either marshaling or unmarshaling.
 // The v1 default is true.
-func FormatTimeDurationAsNanosecond(v bool) Options {
+func FormatTimeWithLegacySemantics(v bool) Options {
 	if v {
-		return jsonflags.FormatTimeDurationAsNanosecond | 1
+		return jsonflags.FormatTimeWithLegacySemantics | 1
 	} else {
-		return jsonflags.FormatTimeDurationAsNanosecond | 0
+		return jsonflags.FormatTimeWithLegacySemantics | 0
 	}
 }
 


### PR DESCRIPTION
WARNING: This commit contains breaking changes.

Rename FormatTimeDurationAsNanosecond as FormatTimeWithLegacySemantics to cover a wider range of legacy behavior.

In particular, we avoid strict RFC 3339 checks under such a flag. Also, make calling of time.Time behavior mimic how error handling is usually done for other method calls.