### PR TITLE
Remove setting StringifyNumbers for map keys

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -927,10 +927,7 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 			var errUnmarshal error
 			for dec.PeekKind() != '}' {
 				k.SetZero()
-				flagsOriginal := uo.Flags
-				uo.Flags.Set(jsonflags.StringifyNumbers | 1) // stringify for numeric keys
 				err := unmarshalKey(dec, k, uo)
-				uo.Flags = flagsOriginal
 				if err != nil {
 					if isFatalError(err, uo.Flags) {
 						return err


### PR DESCRIPTION
A previous commit (PR #91) already removed support for setting StringifyNumbers and made it the responsibility of arshaler to check whether it was serializing for a JSON object name.

This commit removes one place we accidentally still set the flag.