### PR TITLE
Remove IgnoreStructErrors option

### DIFF
--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -59,7 +59,6 @@ const (
 		CallMethodsWithLegacySemantics |
 		FormatBytesWithLegacySemantics |
 		FormatTimeWithLegacySemantics |
-		IgnoreStructErrors |
 		MatchCaseSensitiveDelimiter |
 		MergeWithLegacySemantics |
 		OmitEmptyWithLegacyDefinition |
@@ -126,7 +125,6 @@ const (
 	CallMethodsWithLegacySemantics  // marshal or unmarshal
 	FormatBytesWithLegacySemantics  // marshal or unmarshal
 	FormatTimeWithLegacySemantics   // marshal or unmarshal
-	IgnoreStructErrors              // marshal or unmarshal
 	MatchCaseSensitiveDelimiter     // marshal or unmarshal
 	MergeWithLegacySemantics        // unmarshal
 	OmitEmptyWithLegacyDefinition   // marshal

--- a/v1/options.go
+++ b/v1/options.go
@@ -40,7 +40,6 @@ type Options = jsonopts.Options
 //   - [EscapeInvalidUTF8]
 //   - [FormatBytesWithLegacySemantics]
 //   - [FormatTimeWithLegacySemantics]
-//   - [IgnoreStructErrors]
 //   - [MatchCaseSensitiveDelimiter]
 //   - [MergeWithLegacySemantics]
 //   - [OmitEmptyWithLegacyDefinition]


### PR DESCRIPTION
WARNING: This contains breaking changes.

This option was merged into ReportErrorsWithLegacySemantics (#109), but the flag was not deleted in that commit.