### PR TITLE
Deterministically sort by UTF-8 instead of UTF-16

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -9,12 +9,12 @@ import (
 	"io"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/go-json-experiment/json/internal"
 	"github.com/go-json-experiment/json/internal/jsonflags"
 	"github.com/go-json-experiment/json/internal/jsonopts"
-	"github.com/go-json-experiment/json/internal/jsonwire"
 	"github.com/go-json-experiment/json/jsontext"
 )
 
@@ -550,7 +550,6 @@ func putStrings(s *stringSlice) {
 	stringsPools.Put(s)
 }
 
-// Sort sorts the string slice according to RFC 8785, section 3.2.3.
 func (ss *stringSlice) Sort() {
-	slices.SortFunc(*ss, func(x, y string) int { return jsonwire.CompareUTF16(x, y) })
+	slices.SortFunc(*ss, func(x, y string) int { return strings.Compare(x, y) })
 }

--- a/arshal_default.go
+++ b/arshal_default.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/go-json-experiment/json/internal"
@@ -851,7 +852,7 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 				// to reflect.Value as well if the names are equal.
 				// See internal/fmtsort.
 				slices.SortFunc(members, func(x, y member) int {
-					return jsonwire.CompareUTF16(x.name, y.name)
+					return strings.Compare(x.name, y.name)
 				})
 				for _, member := range members {
 					if err := enc.WriteToken(jsontext.String(member.name)); err != nil {


### PR DESCRIPTION
When operating under the Deterministic option,
sort names according to UTF-8 instead of UTF-16.

The practical difference is negligible,
but the JSONv2 discussion revealed that many
objected to sorted according to UTF-16,
which is what RFC 8785 specifies.

Given that Deterministic does not say we comply with RFC 8785, we can choose any arbitrary ordering.