### PR TITLE
Drop PreserveRawString from DefaultOptionsV1

### DIFF
--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -51,7 +51,6 @@ const (
 		EscapeForHTML |
 		EscapeForJS |
 		EscapeWithLegacySemantics |
-		PreserveRawStrings |
 		Deterministic |
 		FormatNilMapAsNull |
 		FormatNilSliceAsNull |
@@ -86,7 +85,7 @@ const (
 	AllowInvalidUTF8          // encode or decode
 	WithinArshalCall          // encode or decode; for internal use by json.Marshal and json.Unmarshal
 	OmitTopLevelNewline       // encode only; for internal use by json.Marshal and json.MarshalWrite
-	PreserveRawStrings        // encode only; exposed in v1 and also used by jsontext.Value.Canonicalize
+	PreserveRawStrings        // encode only; for internal use by jsontext.Value.reformat
 	CanonicalizeNumbers       // encode only; for internal use by jsontext.Value.Canonicalize
 	EscapeForHTML             // encode only
 	EscapeForJS               // encode only


### PR DESCRIPTION
In #119, we folded legacy string escaping behavior into the EscapeWithLegacySemantics flag, but forgot to drop PreserveRawString from being specified as part of DefaultOptionsV1.