### PR TITLE
Rename MarshalJSONV2 and UnmarshalJSONV2 using To and From suffix

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -51,10 +51,10 @@ func putStructOptions(o *jsonopts.Struct) {
 //     If all applicable functions return [SkipFunc],
 //     then the value is encoded according to subsequent rules.
 //
-//   - If the value type implements [MarshalerV2],
-//     then the MarshalJSONV2 method is called to encode the value.
+//   - If the value type implements [MarshalerTo],
+//     then the MarshalJSONTo method is called to encode the value.
 //
-//   - If the value type implements [MarshalerV1],
+//   - If the value type implements [Marshaler],
 //     then the MarshalJSON method is called to encode the value.
 //
 //   - If the value type implements [encoding.TextMarshaler],
@@ -254,10 +254,10 @@ func marshalEncode(out *jsontext.Encoder, in any, mo *jsonopts.Struct) (err erro
 //     value. If all applicable functions return [SkipFunc],
 //     then the input is decoded according to subsequent rules.
 //
-//   - If the value type implements [UnmarshalerV2],
-//     then the UnmarshalJSONV2 method is called to decode the JSON value.
+//   - If the value type implements [UnmarshalerFrom],
+//     then the UnmarshalJSONFrom method is called to decode the JSON value.
 //
-//   - If the value type implements [UnmarshalerV1],
+//   - If the value type implements [Unmarshaler],
 //     then the UnmarshalJSON method is called to decode the JSON value.
 //
 //   - If the value type implements [encoding.TextUnmarshaler],

--- a/arshal_default.go
+++ b/arshal_default.go
@@ -1705,10 +1705,10 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 			if va.Elem().Kind() == reflect.Pointer && va.Elem().IsNil() {
 				v2 := newAddressableValue(whichMarshaler)
 				switch whichMarshaler {
-				case jsonMarshalerV2Type:
-					v2.Set(reflect.ValueOf(struct{ MarshalerV2 }{va.Elem().Interface().(MarshalerV2)}))
-				case jsonMarshalerV1Type:
-					v2.Set(reflect.ValueOf(struct{ MarshalerV1 }{va.Elem().Interface().(MarshalerV1)}))
+				case jsonMarshalerToType:
+					v2.Set(reflect.ValueOf(struct{ MarshalerTo }{va.Elem().Interface().(MarshalerTo)}))
+				case jsonMarshalerType:
+					v2.Set(reflect.ValueOf(struct{ Marshaler }{va.Elem().Interface().(Marshaler)}))
 				case textAppenderType:
 					v2.Set(reflect.ValueOf(struct{ encodingTextAppender }{va.Elem().Interface().(encodingTextAppender)}))
 				case textMarshalerType:

--- a/arshal_funcs.go
+++ b/arshal_funcs.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-json-experiment/json/jsontext"
 )
 
-// SkipFunc may be returned by [MarshalFuncV2] and [UnmarshalFuncV2] functions.
+// SkipFunc may be returned by [MarshalToFunc] and [UnmarshalFromFunc] functions.
 //
 // Any function that returns SkipFunc must not cause observable side effects
 // on the provided [jsontext.Encoder] or [jsontext.Decoder].
@@ -160,7 +160,7 @@ func (a *typedArshalers[Coder]) lookup(fnc func(*Coder, addressableValue, *jsono
 	return v.(func(*Coder, addressableValue, *jsonopts.Struct) error), true
 }
 
-// MarshalFuncV1 constructs a type-specific marshaler that
+// MarshalFunc constructs a type-specific marshaler that
 // specifies how to marshal values of type T.
 // T can be any type except a named pointer.
 // The function is always provided with a non-nil pointer value
@@ -169,7 +169,7 @@ func (a *typedArshalers[Coder]) lookup(fnc func(*Coder, addressableValue, *jsono
 // The function must marshal exactly one JSON value.
 // The value of T must not be retained outside the function call.
 // It may not return [SkipFunc].
-func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
+func MarshalFunc[T any](fn func(T) ([]byte, error)) *Marshalers {
 	t := reflect.TypeFor[T]()
 	assertCastableTo(t, true)
 	typFnc := typedMarshaler{
@@ -179,14 +179,14 @@ func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal function of type func(T) ([]byte, error)")
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
-					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFuncV1") // unlike unmarshal, always wrapped
+					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFunc") // unlike unmarshal, always wrapped
 				}
 				err = newMarshalErrorBefore(enc, t, err)
 				return collapseSemanticErrors(err)
 			}
 			if err := enc.WriteValue(val); err != nil {
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
-					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFuncV1") // unlike unmarshal, always wrapped
+					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFunc") // unlike unmarshal, always wrapped
 				}
 				if isSyntacticError(err) {
 					err = newMarshalErrorBefore(enc, t, err)
@@ -199,7 +199,7 @@ func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
 	return &Marshalers{fncVals: []typedMarshaler{typFnc}, fromAny: castableToFromAny(t)}
 }
 
-// MarshalFuncV2 constructs a type-specific marshaler that
+// MarshalToFunc constructs a type-specific marshaler that
 // specifies how to marshal values of type T.
 // T can be any type except a named pointer.
 // The function is always provided with a non-nil pointer value
@@ -211,7 +211,7 @@ func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
 // be called on the encoder if [SkipFunc] is returned.
 // The pointer to [jsontext.Encoder], the value of T, and the [Options] value
 // must not be retained outside the function call.
-func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshalers {
+func MarshalToFunc[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshalers {
 	t := reflect.TypeFor[T]()
 	assertCastableTo(t, true)
 	typFnc := typedMarshaler{
@@ -234,7 +234,7 @@ func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshal
 					err = errSkipMutation
 				}
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
-					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalFuncV2") // unlike unmarshal, always wrapped
+					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalToFunc") // unlike unmarshal, always wrapped
 				}
 				if !export.IsIOError(err) {
 					err = newSemanticErrorWithPosition(enc, t, prevDepth, prevLength, err)
@@ -248,7 +248,7 @@ func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshal
 	return &Marshalers{fncVals: []typedMarshaler{typFnc}, fromAny: castableToFromAny(t)}
 }
 
-// UnmarshalFuncV1 constructs a type-specific unmarshaler that
+// UnmarshalFunc constructs a type-specific unmarshaler that
 // specifies how to unmarshal values of type T.
 // T must be an unnamed pointer or an interface type.
 // The function is always provided with a non-nil pointer value.
@@ -257,7 +257,7 @@ func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshal
 // The input []byte must not be mutated.
 // The input []byte and value T must not be retained outside the function call.
 // It may not return [SkipFunc].
-func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
+func UnmarshalFunc[T any](fn func([]byte, T) error) *Unmarshalers {
 	t := reflect.TypeFor[T]()
 	assertCastableTo(t, false)
 	typFnc := typedUnmarshaler{
@@ -282,7 +282,7 @@ func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
 	return &Unmarshalers{fncVals: []typedUnmarshaler{typFnc}, fromAny: castableToFromAny(t)}
 }
 
-// UnmarshalFuncV2 constructs a type-specific unmarshaler that
+// UnmarshalFromFunc constructs a type-specific unmarshaler that
 // specifies how to unmarshal values of type T.
 // T must be an unnamed pointer or an interface type.
 // The function is always provided with a non-nil pointer value.
@@ -293,7 +293,7 @@ func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
 // be called on the decoder if [SkipFunc] is returned.
 // The pointer to [jsontext.Decoder], the value of T, and [Options] value
 // must not be retained outside the function call.
-func UnmarshalFuncV2[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmarshalers {
+func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmarshalers {
 	t := reflect.TypeFor[T]()
 	assertCastableTo(t, false)
 	typFnc := typedUnmarshaler{
@@ -427,4 +427,24 @@ func wrapSkipFunc(err error, what string) error {
 		return errors.New(what + " cannot be skipped")
 	}
 	return err
+}
+
+// Deprecated: Use [MarshalFunc] instead.
+func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
+	return MarshalFunc(fn)
+}
+
+// Deprecated: Use [MarshalToFunc] instead.
+func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshalers {
+	return MarshalToFunc(fn)
+}
+
+// Deprecated: Use [UnmarshalFunc] instead.
+func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
+	return UnmarshalFunc(fn)
+}
+
+// Deprecated: Use [UnmarshalFromFunc] instead.
+func UnmarshalFuncV2[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmarshalers {
+	return UnmarshalFromFunc(fn)
 }

--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -20,21 +20,24 @@ var errNonStringValue = errors.New("JSON value must be string type")
 
 // Interfaces for custom serialization.
 var (
-	jsonMarshalerV1Type   = reflect.TypeFor[MarshalerV1]()
-	jsonMarshalerV2Type   = reflect.TypeFor[MarshalerV2]()
-	jsonUnmarshalerV1Type = reflect.TypeFor[UnmarshalerV1]()
-	jsonUnmarshalerV2Type = reflect.TypeFor[UnmarshalerV2]()
-	textAppenderType      = reflect.TypeFor[encodingTextAppender]()
-	textMarshalerType     = reflect.TypeFor[encoding.TextMarshaler]()
-	textUnmarshalerType   = reflect.TypeFor[encoding.TextUnmarshaler]()
+	jsonMarshalerType       = reflect.TypeFor[Marshaler]()
+	jsonMarshalerToType     = reflect.TypeFor[MarshalerTo]()
+	jsonUnmarshalerType     = reflect.TypeFor[Unmarshaler]()
+	jsonUnmarshalerFromType = reflect.TypeFor[UnmarshalerFrom]()
+	textAppenderType        = reflect.TypeFor[encodingTextAppender]()
+	textMarshalerType       = reflect.TypeFor[encoding.TextMarshaler]()
+	textUnmarshalerType     = reflect.TypeFor[encoding.TextUnmarshaler]()
 
 	// TODO(https://go.dev/issue/62384): Use encoding.TextAppender instead of this hack.
 	// This exists for now to provide performance benefits to netip types.
 	// There is no semantic difference with this change.
 	appenderToType = reflect.TypeFor[interface{ AppendTo([]byte) []byte }]()
 
-	allMarshalerTypes   = []reflect.Type{jsonMarshalerV2Type, jsonMarshalerV1Type, textAppenderType, textMarshalerType}
-	allUnmarshalerTypes = []reflect.Type{jsonUnmarshalerV2Type, jsonUnmarshalerV1Type, textUnmarshalerType}
+	jsonMarshalerV2Type   = reflect.TypeFor[MarshalerV2]()
+	jsonUnmarshalerV2Type = reflect.TypeFor[UnmarshalerV2]()
+
+	allMarshalerTypes   = []reflect.Type{jsonMarshalerV2Type, jsonMarshalerToType, jsonMarshalerType, textAppenderType, textMarshalerType}
+	allUnmarshalerTypes = []reflect.Type{jsonUnmarshalerV2Type, jsonUnmarshalerFromType, jsonUnmarshalerType, textUnmarshalerType}
 	allMethodTypes      = append(allMarshalerTypes, allUnmarshalerTypes...)
 )
 
@@ -44,34 +47,34 @@ type encodingTextAppender interface {
 	AppendText(b []byte) ([]byte, error)
 }
 
-// MarshalerV1 is implemented by types that can marshal themselves.
-// It is recommended that types implement [MarshalerV2] unless the implementation
+// Marshaler is implemented by types that can marshal themselves.
+// It is recommended that types implement [MarshalerTo] unless the implementation
 // is trying to avoid a hard dependency on the "jsontext" package.
 //
 // It is recommended that implementations return a buffer that is safe
 // for the caller to retain and potentially mutate.
-type MarshalerV1 interface {
+type Marshaler interface {
 	MarshalJSON() ([]byte, error)
 }
 
-// MarshalerV2 is implemented by types that can marshal themselves.
-// It is recommended that types implement MarshalerV2 instead of [MarshalerV1]
+// MarshalerTo is implemented by types that can marshal themselves.
+// It is recommended that types implement MarshalerTo instead of [Marshaler]
 // since this is both more performant and flexible.
-// If a type implements both MarshalerV1 and MarshalerV2,
-// then MarshalerV2 takes precedence. In such a case, both implementations
+// If a type implements both Marshaler and MarshalerTo,
+// then MarshalerTo takes precedence. In such a case, both implementations
 // should aim to have equivalent behavior for the default marshal options.
 //
 // The implementation must write only one JSON value to the Encoder and
 // must not retain the pointer to [jsontext.Encoder] or the [Options] value.
-type MarshalerV2 interface {
-	MarshalJSONV2(*jsontext.Encoder, Options) error
+type MarshalerTo interface {
+	MarshalJSONTo(*jsontext.Encoder, Options) error
 
 	// TODO: Should users call the MarshalEncode function or
 	// should/can they call this method directly? Does it matter?
 }
 
-// UnmarshalerV1 is implemented by types that can unmarshal themselves.
-// It is recommended that types implement [UnmarshalerV2] unless the implementation
+// Unmarshaler is implemented by types that can unmarshal themselves.
+// It is recommended that types implement [UnmarshalerFrom] unless the implementation
 // is trying to avoid a hard dependency on the "jsontext" package.
 //
 // The input can be assumed to be a valid encoding of a JSON value
@@ -81,25 +84,25 @@ type MarshalerV2 interface {
 // unmarshaling into a pre-populated value.
 //
 // Implementations must not retain or mutate the input []byte.
-type UnmarshalerV1 interface {
+type Unmarshaler interface {
 	UnmarshalJSON([]byte) error
 }
 
-// UnmarshalerV2 is implemented by types that can unmarshal themselves.
-// It is recommended that types implement UnmarshalerV2 instead of [UnmarshalerV1]
+// UnmarshalerFrom is implemented by types that can unmarshal themselves.
+// It is recommended that types implement UnmarshalerFrom instead of [Unmarshaler]
 // since this is both more performant and flexible.
-// If a type implements both UnmarshalerV1 and UnmarshalerV2,
-// then UnmarshalerV2 takes precedence. In such a case, both implementations
+// If a type implements both Unmarshaler and UnmarshalerFrom,
+// then UnmarshalerFrom takes precedence. In such a case, both implementations
 // should aim to have equivalent behavior for the default unmarshal options.
 //
 // The implementation must read only one JSON value from the Decoder.
-// It is recommended that UnmarshalJSONV2 implement merge semantics when
+// It is recommended that UnmarshalJSONFrom implement merge semantics when
 // unmarshaling into a pre-populated value.
 //
 // Implementations must not retain the pointer to [jsontext.Decoder] or
 // the [Options] value.
-type UnmarshalerV2 interface {
-	UnmarshalJSONV2(*jsontext.Decoder, Options) error
+type UnmarshalerFrom interface {
+	UnmarshalJSONFrom(*jsontext.Decoder, Options) error
 
 	// TODO: Should users call the UnmarshalDecode function or
 	// should/can they call this method directly? Does it matter?
@@ -177,7 +180,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 		}
 	}
 
-	if needAddr, ok := implements(t, jsonMarshalerV1Type); ok {
+	if needAddr, ok := implements(t, jsonMarshalerType); ok {
 		fncs.nonDefault = true
 		prevMarshal := fncs.marshal
 		fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
@@ -185,7 +188,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				((needAddr && va.forcedAddr) || export.Encoder(enc).Tokens.Last.NeedObjectName()) {
 				return prevMarshal(enc, va, mo)
 			}
-			marshaler := va.Addr().Interface().(MarshalerV1)
+			marshaler := va.Addr().Interface().(Marshaler)
 			val, err := marshaler.MarshalJSON()
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal method")
@@ -239,6 +242,37 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 		}
 	}
 
+	if needAddr, ok := implements(t, jsonMarshalerToType); ok {
+		fncs.nonDefault = true
+		prevMarshal := fncs.marshal
+		fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
+			if mo.Flags.Get(jsonflags.CallMethodsWithLegacySemantics) &&
+				((needAddr && va.forcedAddr) || export.Encoder(enc).Tokens.Last.NeedObjectName()) {
+				return prevMarshal(enc, va, mo)
+			}
+			xe := export.Encoder(enc)
+			prevDepth, prevLength := xe.Tokens.DepthLength()
+			xe.Flags.Set(jsonflags.WithinArshalCall | 1)
+			err := va.Addr().Interface().(MarshalerTo).MarshalJSONTo(enc, mo)
+			xe.Flags.Set(jsonflags.WithinArshalCall | 0)
+			currDepth, currLength := xe.Tokens.DepthLength()
+			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {
+				err = errNonSingularValue
+			}
+			if err != nil {
+				err = wrapSkipFunc(err, "marshal method")
+				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
+					return internal.NewMarshalerError(va.Addr().Interface(), err, "MarshalJSONTo") // unlike unmarshal, always wrapped
+				}
+				if !export.IsIOError(err) {
+					err = newSemanticErrorWithPosition(enc, t, prevDepth, prevLength, err)
+				}
+				return err
+			}
+			return nil
+		}
+	}
+
 	if _, ok := implements(t, textUnmarshalerType); ok {
 		fncs.nonDefault = true
 		fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
@@ -273,7 +307,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 		}
 	}
 
-	if _, ok := implements(t, jsonUnmarshalerV1Type); ok {
+	if _, ok := implements(t, jsonUnmarshalerType); ok {
 		fncs.nonDefault = true
 		prevUnmarshal := fncs.unmarshal
 		fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
@@ -285,7 +319,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			if err != nil {
 				return err // must be a syntactic or I/O error
 			}
-			unmarshaler := va.Addr().Interface().(UnmarshalerV1)
+			unmarshaler := va.Addr().Interface().(Unmarshaler)
 			if err := unmarshaler.UnmarshalJSON(val); err != nil {
 				err = wrapSkipFunc(err, "unmarshal method")
 				if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -310,6 +344,40 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			prevDepth, prevLength := xd.Tokens.DepthLength()
 			xd.Flags.Set(jsonflags.WithinArshalCall | 1)
 			err := va.Addr().Interface().(UnmarshalerV2).UnmarshalJSONV2(dec, uo)
+			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
+			currDepth, currLength := xd.Tokens.DepthLength()
+			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {
+				err = errNonSingularValue
+			}
+			if err != nil {
+				err = wrapSkipFunc(err, "unmarshal method")
+				if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
+					if err2 := xd.SkipUntil(prevDepth, prevLength+1); err2 != nil {
+						return err2
+					}
+					return err // unlike marshal, never wrapped
+				}
+				if !isSyntacticError(err) && !export.IsIOError(err) {
+					err = newSemanticErrorWithPosition(dec, t, prevDepth, prevLength, err)
+				}
+				return err
+			}
+			return nil
+		}
+	}
+
+	if _, ok := implements(t, jsonUnmarshalerFromType); ok {
+		fncs.nonDefault = true
+		prevUnmarshal := fncs.unmarshal
+		fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
+			if uo.Flags.Get(jsonflags.CallMethodsWithLegacySemantics) &&
+				export.Decoder(dec).Tokens.Last.NeedObjectName() {
+				return prevUnmarshal(dec, va, uo)
+			}
+			xd := export.Decoder(dec)
+			prevDepth, prevLength := xd.Tokens.DepthLength()
+			xd.Flags.Set(jsonflags.WithinArshalCall | 1)
+			err := va.Addr().Interface().(UnmarshalerFrom).UnmarshalJSONFrom(dec, uo)
 			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xd.Tokens.DepthLength()
 			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {
@@ -359,4 +427,24 @@ func implements(t, ifaceType reflect.Type) (needAddr, ok bool) {
 	default:
 		return false, false
 	}
+}
+
+// Deprecated: Use [Marshaler] instead.
+type MarshalerV1 interface {
+	MarshalJSON() ([]byte, error)
+}
+
+// Deprecated: Use [MarshalerTo] instead.
+type MarshalerV2 interface {
+	MarshalJSONV2(*jsontext.Encoder, Options) error
+}
+
+// Deprecated: Use [Unmarshaler] instead.
+type UnmarshalerV1 interface {
+	UnmarshalJSON([]byte) error
+}
+
+// Deprecated: Use [UnmarshalerFrom] instead.
+type UnmarshalerV2 interface {
+	UnmarshalJSONV2(*jsontext.Decoder, Options) error
 }

--- a/arshal_time.go
+++ b/arshal_time.go
@@ -29,7 +29,7 @@ var (
 )
 
 func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
-	// Ideally, time types would implement MarshalerV2 and UnmarshalerV2,
+	// Ideally, time types would implement MarshalerTo and UnmarshalerFrom,
 	// but that would incur a dependency on package json from package time.
 	// Given how widely used time is, it is more acceptable that we incur a
 	// dependency on time from json.

--- a/bench_test.go
+++ b/bench_test.go
@@ -215,13 +215,13 @@ func (*jsonArshalerV1) UnmarshalJSON(b []byte) error {
 
 type jsonArshalerV2 struct{ _ [4]int }
 
-func (jsonArshalerV2) MarshalJSONV2(enc *jsontext.Encoder, opts jsonv2.Options) error {
+func (jsonArshalerV2) MarshalJSONTo(enc *jsontext.Encoder, opts jsonv2.Options) error {
 	return enc.WriteToken(jsontext.String("method"))
 }
-func (*jsonArshalerV2) UnmarshalJSONV2(dec *jsontext.Decoder, opts jsonv2.Options) error {
+func (*jsonArshalerV2) UnmarshalJSONFrom(dec *jsontext.Decoder, opts jsonv2.Options) error {
 	b, err := dec.ReadValue()
 	if string(b) != `"method"` {
-		return fmt.Errorf("UnmarshalJSONV2: got %q, want %q", b, `"method"`)
+		return fmt.Errorf("UnmarshalJSONFrom: got %q, want %q", b, `"method"`)
 	}
 	return err
 }

--- a/doc.go
+++ b/doc.go
@@ -30,10 +30,10 @@
 // of how the JSON and Go type systems correspond.
 //
 // Arbitrary Go types can customize their JSON representation by implementing
-// [MarshalerV1], [MarshalerV2], [UnmarshalerV1], or [UnmarshalerV2].
+// [Marshaler], [MarshalerTo], [Unmarshaler], or [UnmarshalerFrom].
 // This provides authors of Go types with control over how their types are
 // serialized as JSON. Alternatively, users can implement functions that match
-// [MarshalFuncV1], [MarshalFuncV2], [UnmarshalFuncV1], or [UnmarshalFuncV2]
+// [MarshalFunc], [MarshalToFunc], [UnmarshalFunc], or [UnmarshalFromFunc]
 // to specify the JSON representation for arbitrary types.
 // This provides callers of JSON functionality with control over
 // how any arbitrary type is serialized as JSON.

--- a/example_orderedobject_test.go
+++ b/example_orderedobject_test.go
@@ -28,8 +28,8 @@ type ObjectMember[V any] struct {
 	Value V
 }
 
-// MarshalJSONV2 encodes obj as a JSON object into enc.
-func (obj *OrderedObject[V]) MarshalJSONV2(enc *jsontext.Encoder, opts json.Options) error {
+// MarshalJSONTo encodes obj as a JSON object into enc.
+func (obj *OrderedObject[V]) MarshalJSONTo(enc *jsontext.Encoder, opts json.Options) error {
 	if err := enc.WriteToken(jsontext.ObjectStart); err != nil {
 		return err
 	}
@@ -48,8 +48,8 @@ func (obj *OrderedObject[V]) MarshalJSONV2(enc *jsontext.Encoder, opts json.Opti
 	return nil
 }
 
-// UnmarshalJSONV2 decodes a JSON object from dec into obj.
-func (obj *OrderedObject[V]) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Options) error {
+// UnmarshalJSONFrom decodes a JSON object from dec into obj.
+func (obj *OrderedObject[V]) UnmarshalJSONFrom(dec *jsontext.Decoder, opts json.Options) error {
 	if k := dec.PeekKind(); k != '{' {
 		return fmt.Errorf("expected object start, but encountered %v", k)
 	}
@@ -73,7 +73,7 @@ func (obj *OrderedObject[V]) UnmarshalJSONV2(dec *jsontext.Decoder, opts json.Op
 }
 
 // The exact order of JSON object can be preserved through the use of a
-// specialized type that implements [MarshalerV2] and [UnmarshalerV2].
+// specialized type that implements [MarshalerTo] and [UnmarshalerFrom].
 func Example_orderedObject() {
 	// Round-trip marshal and unmarshal an ordered object.
 	// We expect the order and duplicity of JSON object members to be preserved.

--- a/example_test.go
+++ b/example_test.go
@@ -529,7 +529,7 @@ func Example_protoJSON() {
 	// Marshal using protojson.Marshal for proto.Message types.
 	b, err := json.Marshal(&value,
 		// Use protojson.Marshal as a type-specific marshaler.
-		json.WithMarshalers(json.MarshalFuncV1(protojson.Marshal)))
+		json.WithMarshalers(json.MarshalFunc(protojson.Marshal)))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func Example_protoJSON() {
 	// Unmarshal using protojson.Unmarshal for proto.Message types.
 	err = json.Unmarshal(b, &value,
 		// Use protojson.Unmarshal as a type-specific unmarshaler.
-		json.WithUnmarshalers(json.UnmarshalFuncV1(protojson.Unmarshal)))
+		json.WithUnmarshalers(json.UnmarshalFunc(protojson.Unmarshal)))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -564,13 +564,13 @@ func ExampleWithMarshalers_errors() {
 			// Suppose we consider strconv.NumError to be a safe to serialize:
 			// this type-specific marshal function intercepts this type
 			// and encodes the error message as a JSON string.
-			json.MarshalFuncV2(func(enc *jsontext.Encoder, err *strconv.NumError, opts json.Options) error {
+			json.MarshalToFunc(func(enc *jsontext.Encoder, err *strconv.NumError, opts json.Options) error {
 				return enc.WriteToken(jsontext.String(err.Error()))
 			}),
 			// Error messages may contain sensitive information that may not
 			// be appropriate to serialize. For all errors not handled above,
 			// report some generic error message.
-			json.MarshalFuncV1(func(error) ([]byte, error) {
+			json.MarshalFunc(func(error) ([]byte, error) {
 				return []byte(`"internal server error"`), nil
 			}),
 		)),
@@ -606,7 +606,7 @@ func ExampleWithUnmarshalers_rawNumber() {
 	err := json.Unmarshal([]byte(input), &value,
 		// Intercept every attempt to unmarshal into the any type.
 		json.WithUnmarshalers(
-			json.UnmarshalFuncV2(func(dec *jsontext.Decoder, val *any, opts json.Options) error {
+			json.UnmarshalFromFunc(func(dec *jsontext.Decoder, val *any, opts json.Options) error {
 				// If the next value to be decoded is a JSON number,
 				// then provide a concrete Go type to unmarshal into.
 				if dec.PeekKind() == '0' {
@@ -654,7 +654,7 @@ func ExampleWithUnmarshalers_recordOffsets() {
 	err := json.Unmarshal([]byte(input), &tunnels,
 		// Intercept every attempt to unmarshal into the Tunnel type.
 		json.WithUnmarshalers(
-			json.UnmarshalFuncV2(func(dec *jsontext.Decoder, tunnel *Tunnel, opts json.Options) error {
+			json.UnmarshalFromFunc(func(dec *jsontext.Decoder, tunnel *Tunnel, opts json.Options) error {
 				// Decoder.InputOffset reports the offset after the last token,
 				// but we want to record the offset before the next token.
 				//

--- a/fields_test.go
+++ b/fields_test.go
@@ -260,17 +260,17 @@ func TestMakeStructFields(t *testing.T) {
 		}{},
 		wantErr: errors.New(`inlined Go struct field A of type struct { json.encodingTextAppender } must not implement marshal or unmarshal methods`),
 	}, {
-		name: jsontest.Name("UnknownJSONMarshalerV1"),
+		name: jsontest.Name("UnknownJSONMarshaler"),
 		in: struct {
-			A struct{ MarshalerV1 } `json:",unknown"`
+			A struct{ Marshaler } `json:",unknown"`
 		}{},
-		wantErr: errors.New(`inlined Go struct field A of type struct { json.MarshalerV1 } must not implement marshal or unmarshal methods`),
+		wantErr: errors.New(`inlined Go struct field A of type struct { json.Marshaler } must not implement marshal or unmarshal methods`),
 	}, {
-		name: jsontest.Name("InlineJSONMarshalerV2"),
+		name: jsontest.Name("InlineJSONMarshalerTo"),
 		in: struct {
-			A struct{ MarshalerV2 } `json:",inline"`
+			A struct{ MarshalerTo } `json:",inline"`
 		}{},
-		wantErr: errors.New(`inlined Go struct field A of type struct { json.MarshalerV2 } must not implement marshal or unmarshal methods`),
+		wantErr: errors.New(`inlined Go struct field A of type struct { json.MarshalerTo } must not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("UnknownTextUnmarshaler"),
 		in: struct {
@@ -278,17 +278,17 @@ func TestMakeStructFields(t *testing.T) {
 		}{},
 		wantErr: errors.New(`inlined Go struct field A of type struct { encoding.TextUnmarshaler } must not implement marshal or unmarshal methods`),
 	}, {
-		name: jsontest.Name("InlineJSONUnmarshalerV1"),
+		name: jsontest.Name("InlineJSONUnmarshaler"),
 		in: struct {
-			A *struct{ UnmarshalerV1 } `json:",inline"`
+			A *struct{ Unmarshaler } `json:",inline"`
 		}{},
-		wantErr: errors.New(`inlined Go struct field A of type struct { json.UnmarshalerV1 } must not implement marshal or unmarshal methods`),
+		wantErr: errors.New(`inlined Go struct field A of type struct { json.Unmarshaler } must not implement marshal or unmarshal methods`),
 	}, {
-		name: jsontest.Name("UnknownJSONUnmarshalerV2"),
+		name: jsontest.Name("UnknownJSONUnmarshalerFrom"),
 		in: struct {
-			A struct{ UnmarshalerV2 } `json:",unknown"`
+			A struct{ UnmarshalerFrom } `json:",unknown"`
 		}{},
-		wantErr: errors.New(`inlined Go struct field A of type struct { json.UnmarshalerV2 } must not implement marshal or unmarshal methods`),
+		wantErr: errors.New(`inlined Go struct field A of type struct { json.UnmarshalerFrom } must not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("UnknownStruct"),
 		in: struct {
@@ -310,7 +310,7 @@ func TestMakeStructFields(t *testing.T) {
 		}{},
 		wantErr: errors.New(`inlined map field A of type map[json.nocaseString]interface {} must have a string key that does not implement marshal or unmarshal methods`),
 	}, {
-		name: jsontest.Name("InlineUnsupported/MapMarshalerV1StringKey"),
+		name: jsontest.Name("InlineUnsupported/MapMarshalerStringKey"),
 		in: struct {
 			A map[stringMarshalEmpty]any `json:",inline"`
 		}{},

--- a/jsontext/decode.go
+++ b/jsontext/decode.go
@@ -125,8 +125,8 @@ func NewDecoder(r io.Reader, opts ...Options) *Decoder {
 
 // Reset resets a decoder such that it is reading afresh from r and
 // configured with the provided options. Reset must not be called on an
-// a Decoder passed to the [encoding/json/v2.UnmarshalerV2.UnmarshalJSONV2] method
-// or the [encoding/json/v2.UnmarshalFuncV2] function.
+// a Decoder passed to the [encoding/json/v2.UnmarshalerFrom.UnmarshalJSONFrom] method
+// or the [encoding/json/v2.UnmarshalFromFunc] function.
 func (d *Decoder) Reset(r io.Reader, opts ...Options) {
 	switch {
 	case d == nil:
@@ -134,7 +134,7 @@ func (d *Decoder) Reset(r io.Reader, opts ...Options) {
 	case r == nil:
 		panic("jsontext: invalid nil io.Reader")
 	case d.s.Flags.Get(jsonflags.WithinArshalCall):
-		panic("jsontext: cannot reset Decoder passed to json.UnmarshalerV2")
+		panic("jsontext: cannot reset Decoder passed to json.UnmarshalerFrom")
 	}
 	d.s.reset(nil, r, opts...)
 }

--- a/jsontext/encode.go
+++ b/jsontext/encode.go
@@ -94,8 +94,8 @@ func NewEncoder(w io.Writer, opts ...Options) *Encoder {
 
 // Reset resets an encoder such that it is writing afresh to w and
 // configured with the provided options. Reset must not be called on
-// a Encoder passed to the [encoding/json/v2.MarshalerV2.MarshalJSONV2] method
-// or the [encoding/json/v2.MarshalFuncV2] function.
+// a Encoder passed to the [encoding/json/v2.MarshalerTo.MarshalJSONTo] method
+// or the [encoding/json/v2.MarshalToFunc] function.
 func (e *Encoder) Reset(w io.Writer, opts ...Options) {
 	switch {
 	case e == nil:
@@ -103,7 +103,7 @@ func (e *Encoder) Reset(w io.Writer, opts ...Options) {
 	case w == nil:
 		panic("jsontext: invalid nil io.Writer")
 	case e.s.Flags.Get(jsonflags.WithinArshalCall):
-		panic("jsontext: cannot reset Encoder passed to json.MarshalerV2")
+		panic("jsontext: cannot reset Encoder passed to json.MarshalerTo")
 	}
 	e.s.reset(nil, w, opts...)
 }

--- a/migrate.sh
+++ b/migrate.sh
@@ -81,14 +81,14 @@ echo "pkg encoding/json, func OmitEmptyWithLegacyDefinition(bool) jsonopts.Optio
 echo "pkg encoding/json, func ReportErrorsWithLegacySemantics(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, func StringifyWithLegacySemantics(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, func UnmarshalArrayFromAnyLength(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json, method (*Number) UnmarshalJSONV2(*jsontext.Decoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json, method (*Number) UnmarshalJSONFrom(*jsontext.Decoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, method (*UnmarshalTypeError) Unwrap() error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json, method (Number) MarshalJSONV2(*jsontext.Encoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json, type Marshaler = json.MarshalerV1 #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json, method (Number) MarshalJSONTo(*jsontext.Encoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json, type Marshaler = json.Marshaler #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, type Options = jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, type RawMessage = jsontext.Value #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, type UnmarshalTypeError struct, Err error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json, type Unmarshaler = json.UnmarshalerV1 #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json, type Unmarshaler = json.Unmarshaler #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AllowDuplicateNames(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AllowInvalidUTF8(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AppendQuote[\$0 interface{ ~[]uint8 | ~string }]([]uint8, \$0) ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
@@ -179,8 +179,8 @@ echo "pkg encoding/json/v2, func GetOption[\$0 interface{}](jsonopts.Options, fu
 echo "pkg encoding/json/v2, func JoinOptions(...jsonopts.Options) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func Marshal(interface{}, ...jsonopts.Options) ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MarshalEncode(*jsontext.Encoder, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func MarshalFuncV1[\$0 interface{}](func(\$0) ([]uint8, error)) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func MarshalFuncV2[\$0 interface{}](func(*jsontext.Encoder, \$0, jsonopts.Options) error) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func MarshalFunc[\$0 interface{}](func(\$0) ([]uint8, error)) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func MarshalToFunc[\$0 interface{}](func(*jsontext.Encoder, \$0, jsonopts.Options) error) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MarshalWrite(io.Writer, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MatchCaseInsensitiveNames(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func NewMarshalers(...*typedArshalers[jsontext.Encoder]) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
@@ -190,17 +190,17 @@ echo "pkg encoding/json/v2, func RejectUnknownMembers(bool) jsonopts.Options #$I
 echo "pkg encoding/json/v2, func StringifyNumbers(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func Unmarshal([]uint8, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func UnmarshalDecode(*jsontext.Decoder, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func UnmarshalFuncV1[\$0 interface{}](func([]uint8, \$0) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func UnmarshalFuncV2[\$0 interface{}](func(*jsontext.Decoder, \$0, jsonopts.Options) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func UnmarshalFunc[\$0 interface{}](func([]uint8, \$0) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func UnmarshalFromFunc[\$0 interface{}](func(*jsontext.Decoder, \$0, jsonopts.Options) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func UnmarshalRead(io.Reader, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func WithMarshalers(*typedArshalers[jsontext.Encoder]) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func WithUnmarshalers(*typedArshalers[jsontext.Decoder]) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, method (*SemanticError) Error() string #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, method (*SemanticError) Unwrap() error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type MarshalerV1 interface { MarshalJSON } #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type MarshalerV1 interface, MarshalJSON() ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type MarshalerV2 interface { MarshalJSONV2 } #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type MarshalerV2 interface, MarshalJSONV2(*jsontext.Encoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type Marshaler interface { MarshalJSON } #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type Marshaler interface, MarshalJSON() ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type MarshalerTo interface { MarshalJSONTo } #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type MarshalerTo interface, MarshalJSONTo(*jsontext.Encoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, type Marshalers = typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, type Options = jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, type SemanticError struct #$ISSUE" >> $GOROOT/api/$FILE
@@ -210,10 +210,10 @@ echo "pkg encoding/json/v2, type SemanticError struct, GoType reflect.Type #$ISS
 echo "pkg encoding/json/v2, type SemanticError struct, JSONKind jsontext.Kind #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, type SemanticError struct, JSONPointer jsontext.Pointer #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, type SemanticError struct, JSONValue jsontext.Value #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type UnmarshalerV1 interface { UnmarshalJSON } #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type UnmarshalerV1 interface, UnmarshalJSON([]uint8) error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type UnmarshalerV2 interface { UnmarshalJSONV2 } #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, type UnmarshalerV2 interface, UnmarshalJSONV2(*jsontext.Decoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type Unmarshaler interface { UnmarshalJSON } #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type Unmarshaler interface, UnmarshalJSON([]uint8) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type UnmarshalerFrom interface { UnmarshalJSONFrom } #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, type UnmarshalerFrom interface, UnmarshalJSONFrom(*jsontext.Decoder, jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, type Unmarshalers = typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, var ErrUnknownName error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, var SkipFunc error #$ISSUE" >> $GOROOT/api/$FILE

--- a/options.go
+++ b/options.go
@@ -88,8 +88,8 @@ func JoinOptions(srcs ...Options) Options {
 //	v, ok := json.GetOption(opts, json.Deterministic)
 //
 // Options are most commonly introspected to alter the JSON representation of
-// [MarshalerV2.MarshalJSONV2] and [UnmarshalerV2.UnmarshalJSONV2] methods, and
-// [MarshalFuncV2] and [UnmarshalFuncV2] functions.
+// [MarshalerTo.MarshalJSONTo] and [UnmarshalerFrom.UnmarshalJSONFrom] methods, and
+// [MarshalToFunc] and [UnmarshalFromFunc] functions.
 // In such cases, the presence bit should generally be ignored.
 func GetOption[T any](opts Options, setter func(T) Options) (T, bool) {
 	return jsonopts.GetOption(opts, setter)

--- a/v1/decode.go
+++ b/v1/decode.go
@@ -101,7 +101,7 @@ func Unmarshal(data []byte, v any) error {
 // The input can be assumed to be a valid encoding of
 // a JSON value. UnmarshalJSON must copy the JSON data
 // if it wishes to retain the data after returning.
-type Unmarshaler = jsonv2.UnmarshalerV1
+type Unmarshaler = jsonv2.Unmarshaler
 
 // An UnmarshalTypeError describes a JSON value that was
 // not appropriate for a value of a specific Go type.
@@ -188,8 +188,8 @@ func (n Number) Int64() (int64, error) {
 
 var numberType = reflect.TypeFor[Number]()
 
-// MarshalJSONV2 implements [jsonv2.MarshalerV2].
-func (n Number) MarshalJSONV2(enc *jsontext.Encoder, opts jsonv2.Options) error {
+// MarshalJSONTo implements [jsonv2.MarshalerTo].
+func (n Number) MarshalJSONTo(enc *jsontext.Encoder, opts jsonv2.Options) error {
 	stringify, _ := jsonv2.GetOption(opts, jsonv2.StringifyNumbers)
 	if k, n := enc.StackIndex(enc.StackDepth()); k == '{' && n%2 == 0 {
 		stringify = true // expecting a JSON object name
@@ -212,8 +212,8 @@ func (n Number) MarshalJSONV2(enc *jsontext.Encoder, opts jsonv2.Options) error 
 	return enc.WriteValue(val)
 }
 
-// UnmarshalJSONV2 implements [jsonv2.UnmarshalerV2].
-func (n *Number) UnmarshalJSONV2(dec *jsontext.Decoder, opts jsonv2.Options) error {
+// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+func (n *Number) UnmarshalJSONFrom(dec *jsontext.Decoder, opts jsonv2.Options) error {
 	stringify, _ := jsonv2.GetOption(opts, jsonv2.StringifyNumbers)
 	if k, n := dec.StackIndex(dec.StackDepth()); k == '{' && n%2 == 0 {
 		stringify = true // expecting a JSON object name

--- a/v1/encode.go
+++ b/v1/encode.go
@@ -179,7 +179,7 @@ func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
 
 // Marshaler is the interface implemented by types that
 // can marshal themselves into valid JSON.
-type Marshaler = jsonv2.MarshalerV1
+type Marshaler = jsonv2.Marshaler
 
 // An UnsupportedTypeError is returned by [Marshal] when attempting
 // to encode an unsupported value type.


### PR DESCRIPTION
While the MarshalJSONV2 and UnmarshalJSONV2 methods are technically the "v2" variants of the methods, we could use the To and From suffix that conveys slightly more information.

For example, consider the following user-defined methods:

	func (v MyType) MarshalJSONTo(e *jsontext.Encoder, o json.Options) error
	func (v *MyType) UnmarshalJSONFrom(d *jsontext.Decoder, o json.Options) error

In English, this would naturally read as:

* v will marshal JSON to e
* v will unmarshal JSON from d

The use of the To and From suffix matches the pre-existing io.WriterTo and io.ReaderFrom interfaces, which are optimized variants of io.Writer and io.Reader.

Thus, we perform the following renames:

* MarshalerV1 -> Marshaler
* MarshalerV2 -> MarshalerTo
* MarshalJSONV2 -> MarshalJSONTo
* MarshalFuncV1 -> MarshalFunc
* MarshalFuncV2 -> MarshalToFunc
* UnmarshalerV1 -> Unmarshaler
* UnmarshalerV2 -> UnmarshalerFrom
* UnmarshalJSONV2 -> UnmarshalJSONFrom
* UnmarshalFuncV1 -> UnmarshalFunc
* UnmarshalFuncV2 -> UnmarshalFromFunc

Note that we keep around the older types and functions so that we have at least 1 commit of dual compatibility.
These will be deleted in a subsequent commit.