### PR TITLE
Remove renamed Marshal and Unmarshal methods and functions

### DIFF
--- a/arshal_funcs.go
+++ b/arshal_funcs.go
@@ -428,23 +428,3 @@ func wrapSkipFunc(err error, what string) error {
 	}
 	return err
 }
-
-// Deprecated: Use [MarshalFunc] instead.
-func MarshalFuncV1[T any](fn func(T) ([]byte, error)) *Marshalers {
-	return MarshalFunc(fn)
-}
-
-// Deprecated: Use [MarshalToFunc] instead.
-func MarshalFuncV2[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshalers {
-	return MarshalToFunc(fn)
-}
-
-// Deprecated: Use [UnmarshalFunc] instead.
-func UnmarshalFuncV1[T any](fn func([]byte, T) error) *Unmarshalers {
-	return UnmarshalFunc(fn)
-}
-
-// Deprecated: Use [UnmarshalFromFunc] instead.
-func UnmarshalFuncV2[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmarshalers {
-	return UnmarshalFromFunc(fn)
-}


### PR DESCRIPTION
WARNING: This commit contains breaking changes.

Remove MarshalerV1, MarshalerV2, UnmarshalerV1, UnmarshalerV2, MarshalFuncV1, MarshalFuncV2, UnmarshalFuncV1, UnmarshalFuncV2, and support for MarshalJSONV1 and UnmarshalJSONV2 methods.

These have been replaced by
Marshaler, MarshalerTo, Unmarshaler, UnmarshalerFrom, MarshalFunc, MarshalToFunc, UnmarshalFunc, UnmarshalFromFunc, and new support for MarshalJSONTo and UnmarshalJSONFrom methods.

Of note, there will not necessarily be a static build failure because of the renamed methods. It is the maintainer's responsibility to verify that MarshalJSONV2 and UnmarshalJSONV2 methods are renamed when updating a dependency on this module.

The prior commit contains support for both MarshalJSONV2 and MarshalJSONTo as well as UnmarshalJSONV2 and UnmarshalJSONFrom.
Use that commit as a staging point to convert code to use the new API.