### PR TITLE
Fix regression with Number parsing behavior

### DIFF
--- a/v1/decode.go
+++ b/v1/decode.go
@@ -231,9 +231,6 @@ func (n *Number) UnmarshalJSONFrom(dec *jsontext.Decoder, opts jsonv2.Options) e
 		}
 		return nil
 	case '"':
-		if !stringify {
-			break
-		}
 		verbatim := jsonwire.ConsumeSimpleString(val) == len(val)
 		val = jsonwire.UnquoteMayCopy(val, verbatim)
 		if n, err := jsonwire.ConsumeNumber(val); n != len(val) || err != nil {

--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -1050,13 +1050,13 @@ var unmarshalTests = []struct {
 		CaseName: Name(""),
 		in:       `"invalid"`,
 		ptr:      new(Number),
-		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[Number]()},
+		err:      &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
 	},
 	{
 		CaseName: Name(""),
 		in:       `{"A":"invalid"}`,
 		ptr:      new(struct{ A Number }),
-		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[Number]()},
+		err:      &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
 	},
 	{
 		CaseName: Name(""),
@@ -1070,7 +1070,50 @@ var unmarshalTests = []struct {
 		CaseName: Name(""),
 		in:       `{"A":"invalid"}`,
 		ptr:      new(map[string]Number),
-		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[Number]()},
+		err:      &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
+	},
+
+	{
+		CaseName: Name(""),
+		in:       `5`,
+		ptr:      new(Number),
+		out:      Number("5"),
+	},
+	{
+		CaseName: Name(""),
+		in:       `"5"`,
+		ptr:      new(Number),
+		out:      Number("5"),
+	},
+	{
+		CaseName: Name(""),
+		in:       `{"N":5}`,
+		ptr:      new(struct{ N Number }),
+		out:      struct{ N Number }{"5"},
+	},
+	{
+		CaseName: Name(""),
+		in:       `{"N":"5"}`,
+		ptr:      new(struct{ N Number }),
+		out:      struct{ N Number }{"5"},
+	},
+	{
+		CaseName: Name(""),
+		in:       `{"N":5}`,
+		ptr: new(struct {
+			N Number `json:",string"`
+		}),
+		err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[Number]()},
+	},
+	{
+		CaseName: Name(""),
+		in:       `{"N":"5"}`,
+		ptr: new(struct {
+			N Number `json:",string"`
+		}),
+		out: struct {
+			N Number `json:",string"`
+		}{"5"},
 	},
 }
 


### PR DESCRIPTION
A Number can parse from a JSON string regardless of whether the `string` option is specified or not.

Note that this makes Number inconsistent with how other numeric types are handled, but we're aiming for preserving legacy behavior rather than what is consistent.

The upstream change to add these tests is in https://go.dev/cl/641416