### PR TITLE
Keep more inline, but non-sensible fields

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -117,7 +117,13 @@ func makeStructFields(root reflect.Type) (sf structFields, serr *SemanticError) 
 					f.inline = false // let `unknown` take precedence
 				default:
 					serr = orErrorf(serr, t, "Go struct field %s cannot have any options other than `inline` or `unknown` specified", sf.Name)
-					continue // invalid inlined field; treat as ignored
+					if f.hasName {
+						continue // invalid inlined field; treat as ignored
+					}
+					f.fieldOptions = fieldOptions{name: f.name, quotedName: f.quotedName, inline: f.inline, unknown: f.unknown}
+					if f.inline && f.unknown {
+						f.inline = false // let `unknown` take precedence
+					}
 				}
 
 				// Reject any types with custom serialization otherwise

--- a/fields_test.go
+++ b/fields_test.go
@@ -246,6 +246,15 @@ func TestMakeStructFields(t *testing.T) {
 		in: struct {
 			A map[string]any `json:",inline,omitempty"`
 		}{},
+		want: structFields{inlinedFallback: &structField{
+			index: []int{0},
+			typ:   reflect.TypeFor[map[string]any](),
+			fieldOptions: fieldOptions{
+				name:       "A",
+				quotedName: `"A"`,
+				inline:     true,
+			},
+		}},
 		wantErr: errors.New("Go struct field A cannot have any options other than `inline` or `unknown` specified"),
 	}, {
 		name: jsontest.Name("InlineTextMarshaler"),


### PR DESCRIPTION
Some existing codebases include struct fields like the following:

    type T struct {
        F `json:",inline,omitempty"`
    }

This is odd since v1 "encoding/json" never supported an `inline` option. This happened to still work in v1 since F is an embedded field.

However, v2 adds explicit support for the `inline` option, but expects specifying it to be sensibly done.
In particular, there is no clear semantic what the combination of both `inline` and `omitempty` means. The `inline` option means that the entirety of all fields in F are promoted to type T (effectively removing F itself as a serializable field). However, the `omitempty` option means that F as a singular field should not be serialized if empty. However, under `inline` semantics F is not up for consideration as a singular field. Thus, `omitempty` has no meaning when specified with `inline`.

Modify v2 to still report an error with this construction, but at least still allow F to be treated as an inlined field. In general, specifying `inline` with any other option means that the other options are effectively ignored.