### PR TITLE
Fix regression in legacy Decoder.Decode error stickiness

### DIFF
--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -1176,6 +1176,23 @@ var unmarshalTests = []struct {
 			N Number `json:",string"`
 		}{"5"},
 	},
+
+	// Verify that syntactic errors are immediately fatal,
+	// while semantic errors are lazily reported
+	// (i.e., allow processing to continue).
+	{
+		CaseName: Name(""),
+		in:       `[1,2,true,4,5}`,
+		ptr:      new([]int),
+		err:      &SyntaxError{msg: "invalid character '}' after array value (expecting ',' or ']')", Offset: len64(`[1,2,true,4,5`)},
+	},
+	{
+		CaseName: Name(""),
+		in:       `[1,2,true,4,5]`,
+		ptr:      new([]int),
+		out:      []int{1, 2, 0, 4, 5},
+		err:      &UnmarshalTypeError{Value: "true", Type: reflect.TypeFor[int](), Field: "2", Offset: len64(`[1,2,`)},
+	},
 }
 
 func TestMarshal(t *testing.T) {

--- a/v1/stream.go
+++ b/v1/stream.go
@@ -63,8 +63,12 @@ func (dec *Decoder) Decode(v any) error {
 	if dec.err != nil {
 		return dec.err
 	}
-	dec.err = jsonv2.UnmarshalDecode(dec.dec, v, dec.opts)
-	return dec.err
+	b, err := dec.dec.ReadValue()
+	if err != nil {
+		dec.err = transformSyntacticError(err)
+		return dec.err
+	}
+	return jsonv2.Unmarshal(b, v, dec.opts)
 }
 
 // Buffered returns a reader of the data remaining in the Decoder's


### PR DESCRIPTION
In v1, the only time dec.err is sticky is for syntactic errors, but unmarshal errors are not preserved.
Thus, perform an explicit ReadValue call that has sticky errors, but return unmarshal errors without any stickiness.

This pulls in https://go.dev/cl/642295 for tests.