### PR TITLE
Fix regression in v1/TestUnmarshalSyntax

### DIFF
--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -2250,6 +2250,7 @@ func TestUnmarshalTypeError(t *testing.T) {
 }
 
 func TestUnmarshalSyntax(t *testing.T) {
+	var x any
 	tests := []struct {
 		CaseName
 		in string
@@ -2265,7 +2266,6 @@ func TestUnmarshalSyntax(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			var x any
 			err := Unmarshal([]byte(tt.in), &x)
 			if _, ok := err.(*SyntaxError); !ok {
 				t.Errorf("%s: Unmarshal(%#q, any):\n\tgot:  %T\n\twant: %T",


### PR DESCRIPTION
Revert changes in TestUnmarshalSyntax to exactly match this test upstream in the Go toolchain.

The movement of the x declaration was originally because we did not yet implement legacy merge semantics,
but that is no longer the case today.