### PR TITLE
Fix regression with inlined type with methods

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -131,7 +131,6 @@ func makeStructFields(root reflect.Type) (sf structFields, serr *SemanticError) 
 				tf := indirectType(f.typ)
 				if implementsAny(tf, allMethodTypes...) && tf != jsontextValueType {
 					serr = orErrorf(serr, t, "inlined Go struct field %s of type %s must not implement marshal or unmarshal methods", sf.Name, tf)
-					continue // invalid inlined field; treat as ignored
 				}
 
 				// Handle an inlined field that serializes to/from

--- a/fields_test.go
+++ b/fields_test.go
@@ -261,6 +261,14 @@ func TestMakeStructFields(t *testing.T) {
 		in: struct {
 			A struct{ encoding.TextMarshaler } `json:",inline"`
 		}{},
+		want: structFields{flattened: []structField{{
+			index: []int{0, 0},
+			typ:   reflect.TypeFor[encoding.TextMarshaler](),
+			fieldOptions: fieldOptions{
+				name:       "TextMarshaler",
+				quotedName: `"TextMarshaler"`,
+			},
+		}}},
 		wantErr: errors.New(`inlined Go struct field A of type struct { encoding.TextMarshaler } must not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("InlineTextAppender"),
@@ -279,6 +287,14 @@ func TestMakeStructFields(t *testing.T) {
 		in: struct {
 			A struct{ MarshalerTo } `json:",inline"`
 		}{},
+		want: structFields{flattened: []structField{{
+			index: []int{0, 0},
+			typ:   reflect.TypeFor[MarshalerTo](),
+			fieldOptions: fieldOptions{
+				name:       "MarshalerTo",
+				quotedName: `"MarshalerTo"`,
+			},
+		}}},
 		wantErr: errors.New(`inlined Go struct field A of type struct { json.MarshalerTo } must not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("UnknownTextUnmarshaler"),
@@ -291,6 +307,14 @@ func TestMakeStructFields(t *testing.T) {
 		in: struct {
 			A *struct{ Unmarshaler } `json:",inline"`
 		}{},
+		want: structFields{flattened: []structField{{
+			index: []int{0, 0},
+			typ:   reflect.TypeFor[Unmarshaler](),
+			fieldOptions: fieldOptions{
+				name:       "Unmarshaler",
+				quotedName: `"Unmarshaler"`,
+			},
+		}}},
 		wantErr: errors.New(`inlined Go struct field A of type struct { json.Unmarshaler } must not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("UnknownJSONUnmarshalerFrom"),


### PR DESCRIPTION
In v2, we report an error if an inlined struct type also has marshal or unmarshal methods. In such a case, it is ambiguous how we are supposed to inline the type. The presence of methods indicates that the type has custom serialization behavior, but inlining seems to suggest that we should serialize the type as a Go struct.

Instead of skipping the field, still add the field to the queue so that we can process the type's fields as if they were JSON serializable.