### PR TITLE
Refactor jsontext formatting APIs

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -595,10 +595,10 @@ func runValue(tb testing.TB) {
 
 	methods := []struct {
 		name   string
-		format func(*jsontext.Value) error
+		format func(*jsontext.Value, ...jsontext.Options) error
 	}{
 		{"Compact", (*jsontext.Value).Compact},
-		{"Indent", func(v *jsontext.Value) error { return v.Indent("\t", "    ") }},
+		{"Indent", (*jsontext.Value).Indent},
 		{"Canonicalize", (*jsontext.Value).Canonicalize},
 	}
 

--- a/example_orderedobject_test.go
+++ b/example_orderedobject_test.go
@@ -99,7 +99,7 @@ func Example_orderedObject() {
 	}
 
 	// Print the serialized JSON object.
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
+	(*jsontext.Value)(&b).Indent() // indent for readability
 	fmt.Println(string(b))
 
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -34,7 +34,7 @@ func Example_textMarshal() {
 		netip.MustParseAddr("192.168.0.101"): "obsidian",
 		netip.MustParseAddr("192.168.0.102"): "diamond",
 	}
-	b, err := json.Marshal(&want)
+	b, err := json.Marshal(&want, json.Deterministic(true))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,10 +49,8 @@ func Example_textMarshal() {
 		log.Fatalf("roundtrip mismatch: got %v, want %v", got, want)
 	}
 
-	// Print the serialized JSON object. Canonicalize the JSON first since
-	// Go map entries are not serialized in a deterministic order.
-	(*jsontext.Value)(&b).Canonicalize()
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
+	// Print the serialized JSON object.
+	(*jsontext.Value)(&b).Indent() // indent for readability
 	fmt.Println(string(b))
 
 	// Output:
@@ -93,7 +91,7 @@ func Example_fieldNames() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
+	(*jsontext.Value)(&b).Indent() // indent for readability
 	fmt.Println(string(b))
 
 	// Output:
@@ -218,8 +216,8 @@ func Example_omitFields() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
-	fmt.Println("OmitZero:", string(b))    // outputs "Struct", "Slice", "Map", "Pointer", and "Interface"
+	(*jsontext.Value)(&b).Indent()      // indent for readability
+	fmt.Println("OmitZero:", string(b)) // outputs "Struct", "Slice", "Map", "Pointer", and "Interface"
 
 	// Demonstrate behavior of "omitempty".
 	b, err = json.Marshal(struct {
@@ -264,8 +262,8 @@ func Example_omitFields() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
-	fmt.Println("OmitEmpty:", string(b))   // outputs "Bool", "Int", and "Time"
+	(*jsontext.Value)(&b).Indent()       // indent for readability
+	fmt.Println("OmitEmpty:", string(b)) // outputs "Bool", "Int", and "Time"
 
 	// Output:
 	// OmitZero: {
@@ -323,7 +321,7 @@ func Example_inlinedFields() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
+	(*jsontext.Value)(&b).Indent() // indent for readability
 	fmt.Println(string(b))
 
 	// Output:
@@ -431,7 +429,7 @@ func Example_formatFlags() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	(*jsontext.Value)(&b).Indent("", "\t") // indent for readability
+	(*jsontext.Value)(&b).Indent() // indent for readability
 	fmt.Println(string(b))
 
 	// Output:

--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -50,7 +50,8 @@ const (
 		AllowInvalidUTF8 |
 		EscapeForHTML |
 		EscapeForJS |
-		EscapeWithLegacySemantics |
+		EscapeInvalidUTF8 |
+		PreserveRawStrings |
 		Deterministic |
 		FormatNilMapAsNull |
 		FormatNilSliceAsNull |
@@ -74,29 +75,34 @@ const (
 	WhitespaceFlags = AnyWhitespace | Indent | IndentPrefix
 
 	// AnyEscape is the set of flags related to escaping in a JSON string.
-	AnyEscape = EscapeForHTML | EscapeForJS | EscapeWithLegacySemantics
+	AnyEscape = EscapeForHTML | EscapeForJS | EscapeInvalidUTF8
+
+	// CanonicalizeNumbers is the set of flags related to raw number canonicalization.
+	CanonicalizeNumbers = CanonicalizeRawInts | CanonicalizeRawFloats
 )
 
 // Encoder and decoder flags.
 const (
 	initFlag Bools = 1 << iota // reserved for the boolean value itself
 
-	AllowDuplicateNames       // encode or decode
-	AllowInvalidUTF8          // encode or decode
-	WithinArshalCall          // encode or decode; for internal use by json.Marshal and json.Unmarshal
-	OmitTopLevelNewline       // encode only; for internal use by json.Marshal and json.MarshalWrite
-	PreserveRawStrings        // encode only; for internal use by jsontext.Value.reformat
-	CanonicalizeNumbers       // encode only; for internal use by jsontext.Value.Canonicalize
-	EscapeForHTML             // encode only
-	EscapeForJS               // encode only
-	EscapeWithLegacySemantics // encode only; only exposed in v1
-	Multiline                 // encode only
-	SpaceAfterColon           // encode only
-	SpaceAfterComma           // encode only
-	Indent                    // encode only; non-boolean flag
-	IndentPrefix              // encode only; non-boolean flag
-	ByteLimit                 // encode or decode; non-boolean flag
-	DepthLimit                // encode or decode; non-boolean flag
+	AllowDuplicateNames   // encode or decode
+	AllowInvalidUTF8      // encode or decode
+	WithinArshalCall      // encode or decode; for internal use by json.Marshal and json.Unmarshal
+	OmitTopLevelNewline   // encode only; for internal use by json.Marshal and json.MarshalWrite
+	PreserveRawStrings    // encode only
+	CanonicalizeRawInts   // encode only
+	CanonicalizeRawFloats // encode only
+	ReorderRawObjects     // encode only
+	EscapeForHTML         // encode only
+	EscapeForJS           // encode only
+	EscapeInvalidUTF8     // encode only; only exposed in v1
+	Multiline             // encode only
+	SpaceAfterColon       // encode only
+	SpaceAfterComma       // encode only
+	Indent                // encode only; non-boolean flag
+	IndentPrefix          // encode only; non-boolean flag
+	ByteLimit             // encode or decode; non-boolean flag
+	DepthLimit            // encode or decode; non-boolean flag
 
 	maxCoderFlag
 )

--- a/internal/jsonwire/encode.go
+++ b/internal/jsonwire/encode.go
@@ -82,10 +82,10 @@ func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes, flags *jsonflag
 
 		// Handle multi-byte Unicode.
 		switch r, rn := utf8.DecodeRuneInString(string(truncateMaxUTF8(src[n:]))); {
-		case r == utf8.RuneError && rn == 1:
+		case isInvalidUTF8(r, rn):
 			hasInvalidUTF8 = true
 			dst = append(dst, src[i:n]...)
-			if flags.Get(jsonflags.EscapeWithLegacySemantics) {
+			if flags.Get(jsonflags.EscapeInvalidUTF8) {
 				dst = append(dst, `\ufffd`...)
 			} else {
 				dst = append(dst, "\ufffd"...)
@@ -145,7 +145,7 @@ func appendEscapedUTF16(dst []byte, x uint16) []byte {
 }
 
 // ReformatString consumes a JSON string from src and appends it to dst,
-// reformatting it if necessary for the given escapeRune parameter.
+// reformatting it if necessary according to the specified flags.
 // It returns the appended output and the number of consumed input bytes.
 func ReformatString(dst, src []byte, flags *jsonflags.Flags) ([]byte, int, error) {
 	// TODO: Should this update ValueFlags as input?
@@ -164,10 +164,10 @@ func ReformatString(dst, src []byte, flags *jsonflags.Flags) ([]byte, int, error
 		return dst, n, nil
 	}
 
-	// Under [jsonflags.EscapeWithLegacySemantics], any pre-escaped sequences
+	// Under [jsonflags.PreserveRawStrings], any pre-escaped sequences
 	// remain escaped, however we still need to respect the
 	// [jsonflags.EscapeForHTML] and [jsonflags.EscapeForJS] options.
-	if flags.Get(jsonflags.EscapeWithLegacySemantics) {
+	if flags.Get(jsonflags.PreserveRawStrings) {
 		var i, lastAppendIndex int
 		for i < n {
 			if c := src[i]; c < utf8.RuneSelf {
@@ -238,23 +238,45 @@ func AppendFloat(dst []byte, src float64, bits int) []byte {
 // ReformatNumber consumes a JSON string from src and appends it to dst,
 // canonicalizing it if specified.
 // It returns the appended output and the number of consumed input bytes.
-func ReformatNumber(dst, src []byte, canonicalize bool) ([]byte, int, error) {
+func ReformatNumber(dst, src []byte, flags *jsonflags.Flags) ([]byte, int, error) {
 	n, err := ConsumeNumber(src)
 	if err != nil {
 		return dst, n, err
 	}
-	if !canonicalize {
+	if !flags.Get(jsonflags.CanonicalizeNumbers) {
 		dst = append(dst, src[:n]...) // copy the number verbatim
 		return dst, n, nil
 	}
 
-	// Canonicalize the number per RFC 8785, section 3.2.2.3.
-	// As an optimization, we can copy integer numbers below 2⁵³ verbatim.
-	const maxExactIntegerDigits = 16 // len(strconv.AppendUint(nil, 1<<53, 10))
-	if n < maxExactIntegerDigits && ConsumeSimpleNumber(src[:n]) == n {
-		dst = append(dst, src[:n]...) // copy the number verbatim
-		return dst, n, nil
+	// Identify the kind of number.
+	var isFloat bool
+	for _, c := range src[:n] {
+		if c == '.' || c == 'e' || c == 'E' {
+			isFloat = true // has fraction or exponent
+			break
+		}
 	}
+
+	// Check if need to canonicalize this kind of number.
+	switch {
+	case string(src[:n]) == "-0":
+		break // canonicalize -0 as 0 regardless of kind
+	case isFloat:
+		if !flags.Get(jsonflags.CanonicalizeRawFloats) {
+			dst = append(dst, src[:n]...) // copy the number verbatim
+			return dst, n, nil
+		}
+	default:
+		// As an optimization, we can copy integer numbers below 2⁵³ verbatim
+		// since the canonical form is always identical.
+		const maxExactIntegerDigits = 16 // len(strconv.AppendUint(nil, 1<<53, 10))
+		if !flags.Get(jsonflags.CanonicalizeRawInts) || n < maxExactIntegerDigits {
+			dst = append(dst, src[:n]...) // copy the number verbatim
+			return dst, n, nil
+		}
+	}
+
+	// Parse and reformat the number (which uses a canonical format).
 	fv, _ := strconv.ParseFloat(string(src[:n]), 64)
 	switch {
 	case fv == 0:

--- a/internal/jsonwire/wire.go
+++ b/internal/jsonwire/wire.go
@@ -76,13 +76,8 @@ func CompareUTF16[Bytes ~[]byte | ~string](x, y Bytes) int {
 		return ('\u0000' <= r && r <= '\uD7FF') || ('\uE000' <= r && r <= '\uFFFF')
 	}
 
-	var invalidUTF8 bool
-	x0, y0 := x, y
 	for {
 		if len(x) == 0 || len(y) == 0 {
-			if len(x) == len(y) && invalidUTF8 {
-				return strings.Compare(string(x0), string(y0))
-			}
 			return cmp.Compare(len(x), len(y))
 		}
 
@@ -114,7 +109,14 @@ func CompareUTF16[Bytes ~[]byte | ~string](x, y Bytes) int {
 		if rx != ry {
 			return cmp.Compare(rx, ry)
 		}
-		invalidUTF8 = invalidUTF8 || (rx == utf8.RuneError && nx == 1) || (ry == utf8.RuneError && ny == 1)
+
+		// Check for invalid UTF-8, in which case,
+		// we just perform a byte-for-byte comparison.
+		if isInvalidUTF8(rx, nx) || isInvalidUTF8(ry, ny) {
+			if x[0] != y[0] {
+				return cmp.Compare(x[0], y[0])
+			}
+		}
 		x, y = x[nx:], y[ny:]
 	}
 }
@@ -181,7 +183,6 @@ func TruncatePointer(s string, n int) string {
 	}
 
 	// Avoid truncation in the middle of a UTF-8 rune.
-	isInvalidUTF8 := func(r rune, rn int) bool { return r == utf8.RuneError && rn == 1 }
 	for i > 0 && isInvalidUTF8(utf8.DecodeLastRuneInString(s[:i])) {
 		i--
 	}
@@ -206,4 +207,8 @@ func TruncatePointer(s string, n int) string {
 		middle = strings.TrimSuffix(middle, "…")
 	}
 	return s[:i] + middle + s[j:]
+}
+
+func isInvalidUTF8(r rune, rn int) bool {
+	return r == utf8.RuneError && rn == 1
 }

--- a/jsontext/encode.go
+++ b/jsontext/encode.go
@@ -372,7 +372,7 @@ func (e *encoderState) WriteToken(t Token) error {
 		}
 		err = e.Tokens.appendString()
 	case '0':
-		if b, err = t.appendNumber(b, e.Flags.Get(jsonflags.CanonicalizeNumbers)); err != nil {
+		if b, err = t.appendNumber(b, &e.Flags); err != nil {
 			break
 		}
 		err = e.Tokens.appendNumber()
@@ -563,12 +563,18 @@ func (e *encoderState) WriteValue(v Value) error {
 		if err = e.Tokens.popObject(); err != nil {
 			panic("BUG: popObject should never fail immediately after pushObject: " + err.Error())
 		}
+		if e.Flags.Get(jsonflags.ReorderRawObjects) {
+			mustReorderObjects(b[pos:])
+		}
 	case '[':
 		if err = e.Tokens.pushArray(); err != nil {
 			break
 		}
 		if err = e.Tokens.popArray(); err != nil {
 			panic("BUG: popArray should never fail immediately after pushArray: " + err.Error())
+		}
+		if e.Flags.Get(jsonflags.ReorderRawObjects) {
+			mustReorderObjects(b[pos:])
 		}
 	}
 	if err != nil {
@@ -678,7 +684,7 @@ func (e *encoderState) reformatValue(dst []byte, src Value, depth int) ([]byte, 
 			dst = append(dst, src[:n]...) // copy simple numbers verbatim
 			return dst, n, nil
 		}
-		return jsonwire.ReformatNumber(dst, src, e.Flags.Get(jsonflags.CanonicalizeNumbers))
+		return jsonwire.ReformatNumber(dst, src, &e.Flags)
 	case '{':
 		return e.reformatObject(dst, src, depth)
 	case '[':

--- a/jsontext/options.go
+++ b/jsontext/options.go
@@ -78,6 +78,78 @@ func EscapeForJS(v bool) Options {
 	}
 }
 
+// PreserveRawStrings specifies that when encoding a raw JSON string in a
+// [jsontext.Token] or [jsontext.Value], pre-escaped sequences
+// in a JSON string are preserved to the output.
+// However, raw strings still respect [EscapeForHTML] and [EscapeForJS]
+// such that the relevant characters are escaped.
+// If [AllowInvalidUTF8] is enabled, bytes of invalid UTF-8
+// are preserved to the output.
+//
+// This only affects encoding and is ignored when decoding.
+func PreserveRawStrings(v bool) Options {
+	if v {
+		return jsonflags.PreserveRawStrings | 1
+	} else {
+		return jsonflags.PreserveRawStrings | 0
+	}
+}
+
+// CanonicalizeRawInts specifies that when encoding a raw JSON
+// integer number (i.e., a number without a fraction and exponent) in a
+// [jsontext.Token] or [jsontext.Value], the number is canonicalized
+// according to RFC 8785, section 3.2.2.3. As a special case,
+// the number -0 is canonicalized as 0.
+//
+// JSON numbers are treated as IEEE 754 double precision numbers.
+// Any numbers with precision beyond what is representable by that form
+// will lose their precision when canonicalized. For example,
+// integer values beyond ±2⁵³ will lose their precision.
+// For example, 1234567890123456789 is formatted as 1234567890123456800.
+//
+// This only affects encoding and is ignored when decoding.
+func CanonicalizeRawInts(v bool) Options {
+	if v {
+		return jsonflags.CanonicalizeRawInts | 1
+	} else {
+		return jsonflags.CanonicalizeRawInts | 0
+	}
+}
+
+// CanonicalizeRawFloats specifies that when encoding a raw JSON
+// floating-pointer number (i.e., a number with a fraction or exponent) in a
+// [jsontext.Token] or [jsontext.Value], the number is canonicalized
+// according to RFC 8785, section 3.2.2.3. As a special case,
+// the number -0 is canonicalized as 0.
+//
+// JSON numbers are treated as IEEE 754 double precision numbers.
+// It is safe to canonicalize a serialized single precision number and
+// parse it back as a single precision number and expect the same value.
+// If a number exceeds ±1.7976931348623157e+308, which is the maximum
+// finite number, then it saturated at that value and formatted as such.
+//
+// This only affects encoding and is ignored when decoding.
+func CanonicalizeRawFloats(v bool) Options {
+	if v {
+		return jsonflags.CanonicalizeRawFloats | 1
+	} else {
+		return jsonflags.CanonicalizeRawFloats | 0
+	}
+}
+
+// ReorderRawObjects specifies that when encoding a raw JSON object in a
+// [jsontext.Value], the object members are reordered according to
+// RFC 8785, section 3.2.3.
+//
+// This only affects encoding and is ignored when decoding.
+func ReorderRawObjects(v bool) Options {
+	if v {
+		return jsonflags.ReorderRawObjects | 1
+	} else {
+		return jsonflags.ReorderRawObjects | 0
+	}
+}
+
 // SpaceAfterColon specifies that the JSON output should emit a space character
 // after each colon separator following a JSON object name.
 // If false, then no space character appears after the colon separator.
@@ -190,6 +262,7 @@ func WithIndentPrefix(prefix string) Options {
 //
 // A non-positive limit is equivalent to no limit at all.
 // If unspecified, the default limit is no limit at all.
+// This affects either encoding or decoding.
 func WithByteLimit(n int64) Options {
 	return jsonopts.ByteLimit(max(n, 0))
 }
@@ -202,6 +275,7 @@ func WithByteLimit(n int64) Options {
 //
 // A non-positive limit is equivalent to no limit at all.
 // If unspecified, the default limit is 10000.
+// This affects either encoding or decoding.
 func WithDepthLimit(n int) Options {
 	return jsonopts.DepthLimit(max(n, 0))
 }

--- a/jsontext/quote.go
+++ b/jsontext/quote.go
@@ -14,6 +14,7 @@ import (
 // It uses the minimal string representation per RFC 8785, section 3.2.2.2.
 // Invalid UTF-8 bytes are replaced with the Unicode replacement character
 // and an error is returned at the end indicating the presence of invalid UTF-8.
+// The dst must not overlap with the src.
 func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error) {
 	dst, err := jsonwire.AppendQuote(dst, src, &jsonflags.Flags{})
 	if err != nil {
@@ -28,6 +29,7 @@ func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error)
 // Invalid UTF-8 bytes are replaced with the Unicode replacement character
 // and an error is returned at the end indicating the presence of invalid UTF-8.
 // Any trailing bytes after the JSON string literal results in an error.
+// The dst must not overlap with the src.
 func AppendUnquote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error) {
 	dst, err := jsonwire.AppendUnquote(dst, src)
 	if err != nil {

--- a/jsontext/token.go
+++ b/jsontext/token.go
@@ -276,15 +276,12 @@ func (t Token) string() (string, []byte) {
 
 // appendNumber appends a JSON number to dst and returns it.
 // It panics if t is not a JSON number.
-func (t Token) appendNumber(dst []byte, canonicalize bool) ([]byte, error) {
+func (t Token) appendNumber(dst []byte, flags *jsonflags.Flags) ([]byte, error) {
 	if raw := t.raw; raw != nil {
 		// Handle raw number value.
 		buf := raw.previousBuffer()
 		if Kind(buf[0]).normalize() == '0' {
-			if !canonicalize {
-				return append(dst, buf...), nil
-			}
-			dst, _, err := jsonwire.ReformatNumber(dst, buf, canonicalize)
+			dst, _, err := jsonwire.ReformatNumber(dst, buf, flags)
 			return dst, err
 		}
 	} else if t.num != 0 {

--- a/jsontext/value.go
+++ b/jsontext/value.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"io"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/go-json-experiment/json/internal/jsonflags"
@@ -17,6 +16,22 @@ import (
 )
 
 // NOTE: Value is analogous to v1 json.RawMessage.
+
+// AppendFormat formats the JSON value in src and appends it to dst
+// according to the specified options.
+// See [Value.Format] for more details about the formatting behavior.
+//
+// The dst and src may overlap.
+// If an error is reported, then the entirety of src is appended to dst.
+func AppendFormat(dst, src []byte, opts ...Options) ([]byte, error) {
+	e := getBufferedEncoder(opts...)
+	defer putBufferedEncoder(e)
+	e.s.Flags.Set(jsonflags.OmitTopLevelNewline | 1)
+	if err := e.s.WriteValue(src); err != nil {
+		return append(dst, src...), err
+	}
+	return append(dst, e.s.Buf...), nil
+}
 
 // Value represents a single raw JSON value, which may be one of the following:
 //   - a JSON literal (i.e., null, true, or false)
@@ -43,48 +58,129 @@ func (v Value) String() string {
 }
 
 // IsValid reports whether the raw JSON value is syntactically valid
-// according to RFC 7493.
+// according to the specified options.
 //
+// By default (if no options are specified), it validates according to RFC 7493.
 // It verifies whether the input is properly encoded as UTF-8,
 // that escape sequences within strings decode to valid Unicode codepoints, and
 // that all names in each object are unique.
 // It does not verify whether numbers are representable within the limits
 // of any common numeric type (e.g., float64, int64, or uint64).
-func (v Value) IsValid() bool {
-	d := getBufferedDecoder(v)
+//
+// Relevant options include:
+//   - [AllowDuplicateNames]
+//   - [AllowInvalidUTF8]
+//
+// All other options are ignored.
+func (v Value) IsValid(opts ...Options) bool {
+	// TODO: Document support for [WithByteLimit] and [WithDepthLimit].
+	d := getBufferedDecoder(v, opts...)
 	defer putBufferedDecoder(d)
 	_, errVal := d.ReadValue()
 	_, errEOF := d.ReadToken()
 	return errVal == nil && errEOF == io.EOF
 }
 
+// Format formats the raw JSON value in place.
+//
+// By default (if no options are specified), it validates according to RFC 7493
+// and produces the minimal JSON representation, where
+// all whitespace is elided and JSON strings use the shortest encoding.
+//
+// Relevant options include:
+//   - [AllowDuplicateNames]
+//   - [AllowInvalidUTF8]
+//   - [EscapeForHTML]
+//   - [EscapeForJS]
+//   - [PreserveRawStrings]
+//   - [CanonicalizeRawInts]
+//   - [CanonicalizeRawFloats]
+//   - [ReorderRawObjects]
+//   - [SpaceAfterColon]
+//   - [SpaceAfterComma]
+//   - [Multiline]
+//   - [WithIndent]
+//   - [WithIndentPrefix]
+//
+// All other options are ignored.
+//
+// It is guaranteed to succeed if the value is valid according to the same options.
+// If the value is already formatted, then the buffer is not mutated.
+func (v *Value) Format(opts ...Options) error {
+	// TODO: Document support for [WithByteLimit] and [WithDepthLimit].
+	return v.format(opts, nil)
+}
+
+// format accepts two []Options to avoid the allocation appending them together.
+// It is equivalent to v.Format(append(opts1, opts2...)...).
+func (v *Value) format(opts1, opts2 []Options) error {
+	e := getBufferedEncoder(opts1...)
+	defer putBufferedEncoder(e)
+	e.s.Join(opts2...)
+	e.s.Flags.Set(jsonflags.OmitTopLevelNewline | 1)
+	if err := e.s.WriteValue(*v); err != nil {
+		return err
+	}
+	if !bytes.Equal(*v, e.s.Buf) {
+		*v = append((*v)[:0], e.s.Buf...)
+	}
+	return nil
+}
+
 // Compact removes all whitespace from the raw JSON value.
 //
-// It does not reformat JSON strings to use any other representation.
-// It is guaranteed to succeed if the input is valid.
-// If the value is already compacted, then the buffer is not mutated.
-func (v *Value) Compact() error {
-	return v.reformat(false, false, "", "")
+// It does not reformat JSON strings or numbers to use any other representation.
+// To maximize the set of JSON values that can be formatted,
+// this permits values with duplicate names and invalid UTF-8.
+//
+// Compact is equivalent to calling [Value.Format] with the following options:
+//   - [AllowDuplicateNames](true)
+//   - [AllowInvalidUTF8](true)
+//   - [PreserveRawStrings](true)
+//
+// Any options specified by the caller are applied after the initial set
+// and may deliberately override prior options.
+func (v *Value) Compact(opts ...Options) error {
+	return v.format([]Options{
+		AllowDuplicateNames(true),
+		AllowInvalidUTF8(true),
+		PreserveRawStrings(true),
+	}, opts)
 }
 
 // Indent reformats the whitespace in the raw JSON value so that each element
-// in a JSON object or array begins on a new, indented line beginning with
-// prefix followed by one or more copies of indent according to the nesting.
-// The value does not begin with the prefix nor any indention,
-// to make it easier to embed inside other formatted JSON data.
+// in a JSON object or array begins on a indented line according to the nesting.
 //
-// It does not reformat JSON strings to use any other representation.
-// It is guaranteed to succeed if the input is valid.
-// If the value is already indented properly, then the buffer is not mutated.
+// It does not reformat JSON strings or numbers to use any other representation.
+// To maximize the set of JSON values that can be formatted,
+// this permits values with duplicate names and invalid UTF-8.
 //
-// The prefix and indent strings must be composed of only spaces and/or tabs.
-func (v *Value) Indent(prefix, indent string) error {
-	return v.reformat(false, true, prefix, indent)
+// Indent is equivalent to calling [Value.Format] with the following options:
+//   - [AllowDuplicateNames](true)
+//   - [AllowInvalidUTF8](true)
+//   - [PreserveRawStrings](true)
+//   - [Multiline](true)
+//
+// Any options specified by the caller are applied after the initial set
+// and may deliberately override prior options.
+func (v *Value) Indent(opts ...Options) error {
+	return v.format([]Options{
+		AllowDuplicateNames(true),
+		AllowInvalidUTF8(true),
+		PreserveRawStrings(true),
+		Multiline(true),
+	}, opts)
 }
 
 // Canonicalize canonicalizes the raw JSON value according to the
 // JSON Canonicalization Scheme (JCS) as defined by RFC 8785
 // where it produces a stable representation of a JSON value.
+//
+// JSON strings are formatted to use their minimal representation,
+// JSON numbers are formatted as double precision numbers according
+// to some stable serialization algorithm.
+// JSON object members are sorted in ascending order by name.
+// All whitespace is removed.
 //
 // The output stability is dependent on the stability of the application data
 // (see RFC 8785, Appendix E). It cannot produce stable output from
@@ -92,20 +188,28 @@ func (v *Value) Indent(prefix, indent string) error {
 // contains ephemeral data (e.g., a frequently changing timestamp),
 // then the value is still unstable regardless of whether this is called.
 //
+// Canonicalize is equivalent to calling [Value.Format] with the following options:
+//   - [CanonicalizeRawInts](true)
+//   - [CanonicalizeRawFloats](true)
+//   - [ReorderRawObjects](true)
+//
+// Any options specified by the caller are applied after the initial set
+// and may deliberately override prior options.
+//
 // Note that JCS treats all JSON numbers as IEEE 754 double precision numbers.
 // Any numbers with precision beyond what is representable by that form
 // will lose their precision when canonicalized. For example, integer values
-// beyond ±2⁵³ will lose their precision. It is recommended that
-// int64 and uint64 data types be represented as a JSON string.
+// beyond ±2⁵³ will lose their precision. To preserve the original representation
+// of JSON integers, additionally set CanonicalizeRawInts to false:
 //
-// It is guaranteed to succeed if the input is valid.
-// If the value is already canonicalized, then the buffer is not mutated.
-func (v *Value) Canonicalize() error {
-	return v.reformat(true, false, "", "")
+//	v.Canonicalize(jsontext.CanonicalizeRawInts(false))
+func (v *Value) Canonicalize(opts ...Options) error {
+	return v.format([]Options{
+		CanonicalizeRawInts(true),
+		CanonicalizeRawFloats(true),
+		ReorderRawObjects(true),
+	}, opts)
 }
-
-// TODO: Instead of implementing the v1 Marshaler/Unmarshaler,
-// consider implementing the v2 versions instead.
 
 // MarshalJSON returns v as the JSON encoding of v.
 // It returns the stored value as the raw JSON output without any validation.
@@ -138,96 +242,62 @@ func (v Value) Kind() Kind {
 	return invalidKind
 }
 
-func (v *Value) reformat(canonical, multiline bool, prefix, indent string) error {
-	// Write the entire value to reformat all tokens and whitespace.
-	e := getBufferedEncoder()
-	defer putBufferedEncoder(e)
-	eo := &e.s.Struct
-	if canonical {
-		eo.Flags.Set(jsonflags.AllowInvalidUTF8 | 0)    // per RFC 8785, section 3.2.4
-		eo.Flags.Set(jsonflags.AllowDuplicateNames | 0) // per RFC 8785, section 3.1
-		eo.Flags.Set(jsonflags.CanonicalizeNumbers | 1) // per RFC 8785, section 3.2.2.3
-		eo.Flags.Set(jsonflags.PreserveRawStrings | 0)  // per RFC 8785, section 3.2.2.2
-		eo.Flags.Set(jsonflags.EscapeForHTML | 0)       // per RFC 8785, section 3.2.2.2
-		eo.Flags.Set(jsonflags.EscapeForJS | 0)         // per RFC 8785, section 3.2.2.2
-		eo.Flags.Set(jsonflags.Multiline | 0)           // per RFC 8785, section 3.2.1
-	} else {
-		if s := strings.TrimLeft(prefix, " \t"); len(s) > 0 {
-			panic("jsontext: invalid character " + jsonwire.QuoteRune(s) + " in indent prefix")
-		}
-		if s := strings.TrimLeft(indent, " \t"); len(s) > 0 {
-			panic("jsontext: invalid character " + jsonwire.QuoteRune(s) + " in indent")
-		}
-		eo.Flags.Set(jsonflags.AllowInvalidUTF8 | 1)
-		eo.Flags.Set(jsonflags.AllowDuplicateNames | 1)
-		eo.Flags.Set(jsonflags.PreserveRawStrings | 1)
-		eo.Flags.Set(jsonflags.EscapeForHTML | 0) // ensure strings are preserved
-		eo.Flags.Set(jsonflags.EscapeForJS | 0)   // ensure strings are preserved
-		if multiline {
-			eo.Flags.Set(jsonflags.Multiline | 1)
-			eo.Flags.Set(jsonflags.SpaceAfterColon | 1)
-			eo.Flags.Set(jsonflags.Indent | 1)
-			eo.Flags.Set(jsonflags.IndentPrefix | 1)
-			eo.IndentPrefix = prefix
-			eo.Indent = indent
-		} else {
-			eo.Flags.Set(jsonflags.Multiline | 0)
-		}
-	}
-	eo.Flags.Set(jsonflags.OmitTopLevelNewline | 1)
-	if err := e.s.WriteValue(*v); err != nil {
-		return err
-	}
+const commaAndWhitespace = ", \n\r\t"
 
-	// For canonical output, we may need to reorder object members.
-	if canonical {
-		// Obtain a buffered encoder just to use its internal buffer as
-		// a scratch buffer in reorderObjects for reordering object members.
-		e2 := getBufferedEncoder()
-		defer putBufferedEncoder(e2)
-
-		// Disable redundant checks performed earlier during encoding.
-		d := getBufferedDecoder(e.s.Buf)
-		defer putBufferedDecoder(d)
-		d.s.Flags.Set(jsonflags.AllowDuplicateNames | jsonflags.AllowInvalidUTF8 | 1)
-		reorderObjects(d, &e2.s.Buf) // per RFC 8785, section 3.2.3
-	}
-
-	// Store the result back into the value if different.
-	if !bytes.Equal(*v, e.s.Buf) {
-		*v = append((*v)[:0], e.s.Buf...)
-	}
-	return nil
+type objectMember struct {
+	// name is the unquoted name.
+	name []byte // e.g., "name"
+	// buffer is the entirety of the raw JSON object member
+	// starting from right after the previous member (or opening '{')
+	// until right after the member value.
+	buffer []byte // e.g., `, \n\r\t"name": "value"`
 }
 
-type memberName struct {
-	// name is the unescaped name.
-	name []byte
-	// before and after are byte offsets into Decoder.buf that represents
-	// the entire name/value pair. It may contain leading commas.
-	before, after int64
+func (x objectMember) Compare(y objectMember) int {
+	if c := jsonwire.CompareUTF16(x.name, y.name); c != 0 {
+		return c
+	}
+	// With [AllowDuplicateNames] or [AllowInvalidUTF8],
+	// names could be identical, so also sort using the member value.
+	return jsonwire.CompareUTF16(
+		bytes.TrimLeft(x.buffer, commaAndWhitespace),
+		bytes.TrimLeft(y.buffer, commaAndWhitespace))
 }
 
-var memberNamePool = sync.Pool{New: func() any { return new([]memberName) }}
+var objectMemberPool = sync.Pool{New: func() any { return new([]objectMember) }}
 
-func getMemberNames() *[]memberName {
-	ns := memberNamePool.Get().(*[]memberName)
+func getObjectMembers() *[]objectMember {
+	ns := objectMemberPool.Get().(*[]objectMember)
 	*ns = (*ns)[:0]
 	return ns
 }
-func putMemberNames(ns *[]memberName) {
+func putObjectMembers(ns *[]objectMember) {
 	if cap(*ns) < 1<<10 {
-		clear(*ns) // avoid pinning name
-		memberNamePool.Put(ns)
+		clear(*ns) // avoid pinning name and buffer
+		objectMemberPool.Put(ns)
 	}
 }
 
-// reorderObjects recursively reorders all object members in place
+// mustReorderObjects reorders in-place all object members in a JSON value,
+// which must be valid otherwise it panics.
+func mustReorderObjects(b []byte) {
+	// Obtain a buffered encoder just to use its internal buffer as
+	// a scratch buffer for reordering object members.
+	e2 := getBufferedEncoder()
+	defer putBufferedEncoder(e2)
+
+	// Disable unnecessary checks to syntactically parse the JSON value.
+	d := getBufferedDecoder(b)
+	defer putBufferedDecoder(d)
+	d.s.Flags.Set(jsonflags.AllowDuplicateNames | jsonflags.AllowInvalidUTF8 | 1)
+	mustReorderObjectsFromDecoder(d, &e2.s.Buf) // per RFC 8785, section 3.2.3
+}
+
+// mustReorderObjectsFromDecoder recursively reorders all object members in place
 // according to the ordering specified in RFC 8785, section 3.2.3.
 //
 // Pre-conditions:
 //   - The value is valid (i.e., no decoder errors should ever occur).
-//   - The value is compact (i.e., no whitespace is present).
 //   - Initial call is provided a Decoder reading from the start of v.
 //
 // Post-conditions:
@@ -237,13 +307,13 @@ func putMemberNames(ns *[]memberName) {
 //
 // The runtime is approximately O(n·log(n)) + O(m·log(m)),
 // where n is len(v) and m is the total number of object members.
-func reorderObjects(d *Decoder, scratch *[]byte) {
-	switch tok, _ := d.ReadToken(); tok.Kind() {
+func mustReorderObjectsFromDecoder(d *Decoder, scratch *[]byte) {
+	switch tok, err := d.ReadToken(); tok.Kind() {
 	case '{':
 		// Iterate and collect the name and offsets for every object member.
-		members := getMemberNames()
-		defer putMemberNames(members)
-		var prevName []byte
+		members := getObjectMembers()
+		defer putObjectMembers(members)
+		var prevMember objectMember
 		isSorted := true
 
 		beforeBody := d.InputOffset() // offset after '{'
@@ -252,14 +322,15 @@ func reorderObjects(d *Decoder, scratch *[]byte) {
 			var flags jsonwire.ValueFlags
 			name, _ := d.s.ReadValue(&flags)
 			name = jsonwire.UnquoteMayCopy(name, flags.IsVerbatim())
-			reorderObjects(d, scratch)
+			mustReorderObjectsFromDecoder(d, scratch)
 			afterValue := d.InputOffset()
 
+			currMember := objectMember{name, d.s.buf[beforeName:afterValue]}
 			if isSorted && len(*members) > 0 {
-				isSorted = jsonwire.CompareUTF16(prevName, []byte(name)) < 0
+				isSorted = objectMember.Compare(prevMember, currMember) < 0
 			}
-			*members = append(*members, memberName{name, beforeName, afterValue})
-			prevName = name
+			*members = append(*members, currMember)
+			prevMember = currMember
 		}
 		afterBody := d.InputOffset() // offset before '}'
 		d.ReadToken()
@@ -268,9 +339,9 @@ func reorderObjects(d *Decoder, scratch *[]byte) {
 		if isSorted {
 			return
 		}
-		slices.SortFunc(*members, func(x, y memberName) int {
-			return jsonwire.CompareUTF16(x.name, y.name)
-		})
+		firstBufferBeforeSorting := (*members)[0].buffer
+		slices.SortFunc(*members, objectMember.Compare)
+		firstBufferAfterSorting := (*members)[0].buffer
 
 		// Append the reordered members to a new buffer,
 		// then copy the reordered members back over the original members.
@@ -280,14 +351,24 @@ func reorderObjects(d *Decoder, scratch *[]byte) {
 		//
 		// The following invariant must hold:
 		//	sum([m.after-m.before for m in members]) == afterBody-beforeBody
+		commaAndWhitespacePrefix := func(b []byte) []byte {
+			return b[:len(b)-len(bytes.TrimLeft(b, commaAndWhitespace))]
+		}
 		sorted := (*scratch)[:0]
 		for i, member := range *members {
-			if d.s.buf[member.before] == ',' {
-				member.before++ // trim leading comma
-			}
-			sorted = append(sorted, d.s.buf[member.before:member.after]...)
-			if i < len(*members)-1 {
-				sorted = append(sorted, ',') // append trailing comma
+			switch {
+			case i == 0 && &member.buffer[0] != &firstBufferBeforeSorting[0]:
+				// First member after sorting is not the first member before sorting,
+				// so use the prefix of the first member before sorting.
+				sorted = append(sorted, commaAndWhitespacePrefix(firstBufferBeforeSorting)...)
+				sorted = append(sorted, bytes.TrimLeft(member.buffer, commaAndWhitespace)...)
+			case i != 0 && &member.buffer[0] == &firstBufferBeforeSorting[0]:
+				// Later member after sorting is the first member before sorting,
+				// so use the prefix of the first member after sorting.
+				sorted = append(sorted, commaAndWhitespacePrefix(firstBufferAfterSorting)...)
+				sorted = append(sorted, bytes.TrimLeft(member.buffer, commaAndWhitespace)...)
+			default:
+				sorted = append(sorted, member.buffer...)
 			}
 		}
 		if int(afterBody-beforeBody) != len(sorted) {
@@ -301,8 +382,12 @@ func reorderObjects(d *Decoder, scratch *[]byte) {
 		}
 	case '[':
 		for d.PeekKind() != ']' {
-			reorderObjects(d, scratch)
+			mustReorderObjectsFromDecoder(d, scratch)
 		}
 		d.ReadToken()
+	default:
+		if err != nil {
+			panic("BUG: " + err.Error())
+		}
 	}
 }

--- a/jsontext/value_test.go
+++ b/jsontext/value_test.go
@@ -47,19 +47,20 @@ var valueTestdata = append(func() (out []valueTestdataEntry) {
 	name: jsontest.Name("RFC8785/Primitives"),
 	in: `{
 		"numbers": [333333333.33333329, 1E30, 4.50,
-					2e-3, 0.000000000000000000000000001],
+					2e-3, 0.000000000000000000000000001, -0],
 		"string": "\u20ac$\u000F\u000aA'\u0042\u0022\u005c\\\"\/",
 		"literals": [null, true, false]
 	}`,
 	wantValid:     true,
-	wantCompacted: `{"numbers":[333333333.33333329,1E30,4.50,2e-3,0.000000000000000000000000001],"string":"\u20ac$\u000F\u000aA'\u0042\u0022\u005c\\\"\/","literals":[null,true,false]}`,
+	wantCompacted: `{"numbers":[333333333.33333329,1E30,4.50,2e-3,0.000000000000000000000000001,-0],"string":"\u20ac$\u000F\u000aA'\u0042\u0022\u005c\\\"\/","literals":[null,true,false]}`,
 	wantIndented: `{
 	    "numbers": [
 	        333333333.33333329,
 	        1E30,
 	        4.50,
 	        2e-3,
-	        0.000000000000000000000000001
+	        0.000000000000000000000000001,
+	        -0
 	    ],
 	    "string": "\u20ac$\u000F\u000aA'\u0042\u0022\u005c\\\"\/",
 	    "literals": [
@@ -68,7 +69,7 @@ var valueTestdata = append(func() (out []valueTestdataEntry) {
 	        false
 	    ]
 	}`,
-	wantCanonicalized: `{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\u000f\nA'B\"\\\\\"/"}`,
+	wantCanonicalized: `{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27,0],"string":"€$\u000f\nA'B\"\\\\\"/"}`,
 }, {
 	name: jsontest.Name("RFC8785/ObjectOrdering"),
 	in: `{
@@ -176,7 +177,7 @@ func TestValueMethods(t *testing.T) {
 			}
 
 			gotIndented := Value(td.in)
-			gotIndentErr := gotIndented.Indent("\t", "    ")
+			gotIndentErr := gotIndented.Indent(WithIndentPrefix("\t"), WithIndent("    "))
 			if string(gotIndented) != td.wantIndented {
 				t.Errorf("%s: Value.Indent = %s, want %s", td.name.Where, gotIndented, td.wantIndented)
 			}

--- a/migrate.sh
+++ b/migrate.sh
@@ -67,7 +67,7 @@ ISSUE=63397 # TODO: Replace with formal proposal issue for encoding/json/v2
 FILE=$(cd $GOROOT/api; ls -v | tail -n 1)
 echo "pkg encoding/json, func CallMethodsWithLegacySemantics(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, func DefaultOptionsV1() jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json, func EscapeWithLegacySemantics(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json, func EscapeInvalidUTF8(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, func FormatBytesWithLegacySemantics(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, func FormatTimeWithLegacySemantics(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json, func MatchCaseSensitiveDelimiter(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
@@ -86,9 +86,12 @@ echo "pkg encoding/json, type UnmarshalTypeError struct, Err error #$ISSUE" >> $
 echo "pkg encoding/json, type Unmarshaler = json.Unmarshaler #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AllowDuplicateNames(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AllowInvalidUTF8(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, func AppendFormat([]uint8, []uint8, ...jsonopts.Options) ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AppendQuote[\$0 interface{ ~[]uint8 | ~string }]([]uint8, \$0) ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func AppendUnquote[\$0 interface{ ~[]uint8 | ~string }]([]uint8, \$0) ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func Bool(bool) Token #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, func CanonicalizeRawFloats(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, func CanonicalizeRawInts(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func EscapeForHTML(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func EscapeForJS(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func Float(float64) Token #$ISSUE" >> $GOROOT/api/$FILE
@@ -96,6 +99,8 @@ echo "pkg encoding/json/jsontext, func Int(int64) Token #$ISSUE" >> $GOROOT/api/
 echo "pkg encoding/json/jsontext, func Multiline(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func NewDecoder(io.Reader, ...jsonopts.Options) *Decoder #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func NewEncoder(io.Writer, ...jsonopts.Options) *Encoder #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, func PreserveRawStrings(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, func ReorderRawObjects(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func SpaceAfterColon(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func SpaceAfterComma(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, func String(string) Token #$ISSUE" >> $GOROOT/api/$FILE
@@ -122,9 +127,10 @@ echo "pkg encoding/json/jsontext, method (*Encoder) WriteToken(Token) error #$IS
 echo "pkg encoding/json/jsontext, method (*Encoder) WriteValue(Value) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (*SyntacticError) Error() string #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (*SyntacticError) Unwrap() error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/jsontext, method (*Value) Canonicalize() error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/jsontext, method (*Value) Compact() error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/jsontext, method (*Value) Indent(string, string) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, method (*Value) Canonicalize(...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, method (*Value) Compact(...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, method (*Value) Format(...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, method (*Value) Indent(...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (*Value) UnmarshalJSON([]uint8) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Kind) String() string #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Pointer) AppendToken(string) Pointer #$ISSUE" >> $GOROOT/api/$FILE
@@ -140,7 +146,7 @@ echo "pkg encoding/json/jsontext, method (Token) Kind() Kind #$ISSUE" >> $GOROOT
 echo "pkg encoding/json/jsontext, method (Token) String() string #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Token) Uint() uint64 #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Value) Clone() Value #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/jsontext, method (Value) IsValid() bool #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/jsontext, method (Value) IsValid(...jsonopts.Options) bool #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Value) Kind() Kind #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Value) MarshalJSON() ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/jsontext, method (Value) String() string #$ISSUE" >> $GOROOT/api/$FILE
@@ -171,22 +177,22 @@ echo "pkg encoding/json/v2, func DiscardUnknownMembers(bool) jsonopts.Options #$
 echo "pkg encoding/json/v2, func FormatNilMapAsNull(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func FormatNilSliceAsNull(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func GetOption[\$0 interface{}](jsonopts.Options, func(\$0) jsonopts.Options) (\$0, bool) #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func JoinMarshalers(...*typedArshalers[jsontext.Encoder]) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func JoinOptions(...jsonopts.Options) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func JoinUnmarshalers(...*typedArshalers[jsontext.Decoder]) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func Marshal(interface{}, ...jsonopts.Options) ([]uint8, error) #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MarshalEncode(*jsontext.Encoder, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MarshalFunc[\$0 interface{}](func(\$0) ([]uint8, error)) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MarshalToFunc[\$0 interface{}](func(*jsontext.Encoder, \$0, jsonopts.Options) error) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MarshalWrite(io.Writer, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func MatchCaseInsensitiveNames(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func JoinMarshalers(...*typedArshalers[jsontext.Encoder]) *typedArshalers[jsontext.Encoder] #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func JoinUnmarshalers(...*typedArshalers[jsontext.Decoder]) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func OmitZeroStructFields(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func RejectUnknownMembers(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func StringifyNumbers(bool) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func Unmarshal([]uint8, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func UnmarshalDecode(*jsontext.Decoder, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
-echo "pkg encoding/json/v2, func UnmarshalFunc[\$0 interface{}](func([]uint8, \$0) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func UnmarshalFromFunc[\$0 interface{}](func(*jsontext.Decoder, \$0, jsonopts.Options) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
+echo "pkg encoding/json/v2, func UnmarshalFunc[\$0 interface{}](func([]uint8, \$0) error) *typedArshalers[jsontext.Decoder] #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func UnmarshalRead(io.Reader, interface{}, ...jsonopts.Options) error #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func WithMarshalers(*typedArshalers[jsontext.Encoder]) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE
 echo "pkg encoding/json/v2, func WithUnmarshalers(*typedArshalers[jsontext.Decoder]) jsonopts.Options #$ISSUE" >> $GOROOT/api/$FILE

--- a/v1/indent.go
+++ b/v1/indent.go
@@ -47,8 +47,11 @@ func appendHTMLEscape(dst, src []byte) []byte {
 func Compact(dst *bytes.Buffer, src []byte) error {
 	dst.Grow(len(src))
 	b := dst.AvailableBuffer()
-	b = append(b, src...)
-	if err := (*jsontext.Value)(&b).Compact(); err != nil {
+	b, err := jsontext.AppendFormat(b, src,
+		jsontext.AllowDuplicateNames(true),
+		jsontext.AllowInvalidUTF8(true),
+		jsontext.PreserveRawStrings(true))
+	if err != nil {
 		return transformSyntacticError(err)
 	}
 	dst.Write(b)
@@ -114,8 +117,14 @@ func appendIndent(dst, src []byte, prefix, indent string) ([]byte, error) {
 		}()
 	}
 
-	dst = append(dst, src...)
-	if err := (*jsontext.Value)(&dst).Indent(prefix, indent); err != nil {
+	dst, err := jsontext.AppendFormat(dst, src,
+		jsontext.AllowDuplicateNames(true),
+		jsontext.AllowInvalidUTF8(true),
+		jsontext.PreserveRawStrings(true),
+		jsontext.Multiline(true),
+		jsontext.WithIndentPrefix(prefix),
+		jsontext.WithIndent(indent))
+	if err != nil {
 		return dst[:dstLen], transformSyntacticError(err)
 	}
 	return dst, nil

--- a/v1/options.go
+++ b/v1/options.go
@@ -195,7 +195,7 @@ type Options = jsonopts.Options
 // It is equivalent to the following boolean options being set to true:
 //
 //   - [CallMethodsWithLegacySemantics]
-//   - [EscapeWithLegacySemantics]
+//   - [EscapeInvalidUTF8]
 //   - [FormatBytesWithLegacySemantics]
 //   - [FormatTimeWithLegacySemantics]
 //   - [MatchCaseSensitiveDelimiter]
@@ -212,6 +212,7 @@ type Options = jsonopts.Options
 //   - [jsontext.AllowInvalidUTF8]
 //   - [jsontext.EscapeForHTML]
 //   - [jsontext.EscapeForJS]
+//   - [jsontext.PreserveRawString]
 //
 // All other boolean options are set to false.
 // All non-boolean options are set to the zero value,
@@ -269,28 +270,20 @@ func CallMethodsWithLegacySemantics(v bool) Options {
 	}
 }
 
-// EscapeWithLegacySemantics specifies that JSON strings are escaped
-// with legacy semantics:
-//
-//   - When encoding a literal [jsontext.Token] with bytes of invalid UTF-8,
-//     such bytes are escaped as a hexadecimal Unicode codepoint (i.e., \ufffd).
-//     In contrast, the v2 default is to use the minimal representation,
-//     which is to encode invalid UTF-8 as the Unicode replacement rune itself
-//     (without any form of escaping).
-//
-//   - When encoding a raw [jsontext.Token] or [jsontext.Value]
-//     pre-escaped sequences in a JSON string are preserved to the output.
-//     In contrast, the v2 default is use the unescaped representation,
-//     and only escape what is necessary to satisfy the
-//     [jsontext.EscapeForHTML] and [jsontext.EscapeForJS] options.
+// EscapeInvalidUTF8 specifies that when encoding a [jsontext.String]
+// with bytes of invalid UTF-8, such bytes are escaped as
+// a hexadecimal Unicode codepoint (i.e., \ufffd).
+// In contrast, the v2 default is to use the minimal representation,
+// which is to encode invalid UTF-8 as the Unicode replacement rune itself
+// (without any form of escaping).
 //
 // This only affects encoding and is ignored when decoding.
 // The v1 default is true.
-func EscapeWithLegacySemantics(v bool) Options {
+func EscapeInvalidUTF8(v bool) Options {
 	if v {
-		return jsonflags.EscapeWithLegacySemantics | 1
+		return jsonflags.EscapeInvalidUTF8 | 1
 	} else {
-		return jsonflags.EscapeWithLegacySemantics | 0
+		return jsonflags.EscapeInvalidUTF8 | 0
 	}
 }
 


### PR DESCRIPTION
WARNING: This commit contains breaking changes.

Newly inserted API:
* jsonv1.EscapeInvalidUTF8
* jsontext.Value.Format
* jsontext.AppendFormat
* jsontext.PreserveRawStrings
* jsontext.CanonicalizeRawInts
* jsontext.CanonicalizeRawFloats
* jsontext.ReorderRawObjects

Modified API:
* jsontext.Value.IsValid now takes in variadic Options
* jsontext.Value.Compact now takes in variadic Options
* jsontext.Value.Indent now takes in variadic Options
* jsontext.Value.Canonicalize now takes in variadic Options

Removed API:
* jsonv1.EscapeWithLegacySemantics

The rationale for this change is due to the overly restricted nature of the IsValid, Compact, Indent, and Canonicalize methods on Value.

For example:

* IsValid validates strictly according to RFC 7493, but there are cases where a user wants looser validation where duplicate names and/or invalid UTF-8 are acceptable.

* Indent previously required the user to also provide the prefix and indent, when most users did not care and only wanted some multiline output. By removing prefix and indent, we simplify the common case. By adding variadic Options, we keep the ability for the user to still specify a prefix and/or indent string.

* Canonicalize was controversial in that some users objected to it reformatting JSON integers (leading to precision loss). By accepting variadic Options, users can more specially configure how canonicalization occurs (include making the output multiline).

We now expose 4 new options that affect the formatting of raw JSON values:

* PreserveRawStrings preserves the exact representation of a JSON string (but still honors EscapeForJS and EscapeForHTML).

* CanonicalizeRawInts canonicalizes raw JSON integer numbers.

* CanonicalizeRawFloats canonicalizes raw JSON floating-point numbers.

* ReorderRawObjects canonicalizes the ordering of raw JSON object members.

The PreserveRawString option is the previously unexported preserveRawString option. The CanonicalizeRawInts and CanonicalizeRawFloats options together form the previously unexported canonicalizeRawNumbers option. They were split apart to provide better control over which kind of numbers that they take effect on.

As part of the refactoring:

* Execute reordering of raw objects in Encoder.WriteValue so that the ReorderRawObjects option is respected by the wider jsontext package.

* Modify CompareUTF16 to better handle invalid UTF-8 by falling back on a byte-for-byte comparison.

* Modify reorderObjects to better handle duplicate names, invalid UTF-8, and the possible presence of whitespace between members. In particular, if two member names are identical, fallback on comparing the raw member representation itself. Rather than removing and inserting a comma between members, generally preserve the comma and whitespace before a member. Only the very first member is ever different from all the other members.