### PR TITLE
Add WithOption for user-specified options

### DIFF
--- a/internal/jsonopts/options.go
+++ b/internal/jsonopts/options.go
@@ -22,6 +22,11 @@ type Struct struct {
 
 	CoderValues
 	ArshalValues
+
+	// UserValues is a map of user-defined option values
+	// keyed by [reflect.Type] to the concrete user-defined value.
+	// The key type is not [reflect.Type] to avoid a dependency on reflect.
+	UserValues map[any]any
 }
 
 type CoderValues struct {
@@ -166,6 +171,14 @@ func (dst *Struct) Join(srcs ...Options) {
 			if src.Format != "" {
 				dst.Format = src.Format
 				dst.FormatDepth = src.FormatDepth
+			}
+			if len(src.UserValues) > 0 {
+				if dst.UserValues == nil {
+					dst.UserValues = make(map[any]any)
+				}
+				for k, v := range src.UserValues {
+					dst.UserValues[k] = v
+				}
 			}
 		default:
 			JoinUnknownOption(dst, src)


### PR DESCRIPTION
DO NOT SUBMIT: For experimental prototyping only.

The Options type is now plumbed up/down the call stack of
MarshalerTo and UnmarshalerFrom method calls.
There is value in allowing user-defined option values that
can alter the behavior of user-defined methods.

The WithOption function is parameterized on a particular T
and constructs a user-defined option of type T.
That single function can also be used to retrieve the option.