### PR TITLE
 Remove jsonwire.ParseFloat fast path

### DIFF
--- a/internal/jsonwire/decode.go
+++ b/internal/jsonwire/decode.go
@@ -610,19 +610,6 @@ func ParseUint(b []byte) (v uint64, ok bool) {
 // then we return MaxFloat since any finite value will always be infinitely
 // more accurate at representing another finite value than an infinite value.
 func ParseFloat(b []byte, bits int) (v float64, ok bool) {
-	// Fast path for exact integer numbers which fit in the
-	// 24-bit or 53-bit significand of a float32 or float64.
-	var negLen int // either 0 or 1
-	if len(b) > 0 && b[0] == '-' {
-		negLen = 1
-	}
-	u, ok := ParseUint(b[negLen:])
-	if ok && ((bits == 32 && u <= 1<<24) || (bits == 64 && u <= 1<<53)) {
-		return math.Copysign(float64(u), float64(-1*negLen)), true
-	}
-
-	// Note that the []byte->string conversion unfortunately allocates.
-	// See https://go.dev/issue/42429 for more information.
 	fv, err := strconv.ParseFloat(string(b), bits)
 	if math.IsInf(fv, 0) {
 		switch {


### PR DESCRIPTION
Calling `strconv.ParseFloat()` does not allocate now, so the necessity of fast path is reduced. This fast path actually slows down the process when it fails.

If overflows, return infinity as all other libs, don't give surprise to user. Since we now always treat overflow as error, this may not be very important, but still a breaking change.

Simple benchmark for your reference
```golang
func BenchmarkParseFloat_NoPoint(b *testing.B) {
	data := []byte("123456789")
	for range b.N {
		ParseFloat(data, 64)
	}
}

func BenchmarkParseFloat_WithPoint(b *testing.B) {
	data := []byte("1234567.89")
	for range b.N {
		ParseFloat(data, 64)
	}
}

func BenchmarkParseFloat_Overflow(b *testing.B) {
	data := []byte("1e1000")
	for range b.N {
		ParseFloat(data, 64)
	}
}
```
before
```
goos: darwin
goarch: arm64
pkg: github.com/go-json-experiment/json/internal/jsonwire
cpu: Apple M2 Pro
BenchmarkParseFloat_NoPoint-12          152670760                7.743 ns/op           0 B/op          0 allocs/op
BenchmarkParseFloat_WithPoint-12        37303958                31.28 ns/op            0 B/op          0 allocs/op
BenchmarkParseFloat_Overflow-12         16789585                69.25 ns/op           56 B/op          2 allocs/op
PASS
ok      github.com/go-json-experiment/json/internal/jsonwire    4.774s
```
after
```
goos: darwin
goarch: arm64
pkg: github.com/go-json-experiment/json/internal/jsonwire
cpu: Apple M2 Pro
BenchmarkParseFloat_NoPoint-12          48795962                24.33 ns/op            0 B/op          0 allocs/op
BenchmarkParseFloat_WithPoint-12        45615379                25.68 ns/op            0 B/op          0 allocs/op
BenchmarkParseFloat_Overflow-12         17682922                65.94 ns/op           56 B/op          2 allocs/op
PASS
ok      github.com/go-json-experiment/json/internal/jsonwire    4.707s
```

Float overflow behavior of other libs:

python3
```
Python 3.13.1 (main, Dec  3 2024, 17:59:52) [Clang 16.0.0 (clang-1600.0.26.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> json.loads("1e1000")
inf
```

Chrome
```
> JSON.parse("1e1000")
< Infinity
```