### PR TITLE
Optimize direct copy of field name for v1

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -1106,7 +1106,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 
 				// Append the token to the output and to the state machine.
 				n0 := len(b) // offset before calling AppendQuote
-				if !mo.Flags.Get(jsonflags.AnyEscape) {
+				if !f.nameNeedEscape {
 					b = append(b, f.quotedName...)
 				} else {
 					b, _ = jsonwire.AppendQuote(b, f.name, &mo.Flags)

--- a/fields.go
+++ b/fields.go
@@ -361,16 +361,17 @@ const (
 )
 
 type fieldOptions struct {
-	name       string
-	quotedName string // quoted name per RFC 8785, section 3.2.2.2.
-	hasName    bool
-	casing     int8 // either 0, nocase, or strictcase
-	inline     bool
-	unknown    bool
-	omitzero   bool
-	omitempty  bool
-	string     bool
-	format     string
+	name           string
+	quotedName     string // quoted name per RFC 8785, section 3.2.2.2.
+	hasName        bool
+	nameNeedEscape bool
+	casing         int8 // either 0, nocase, or strictcase
+	inline         bool
+	unknown        bool
+	omitzero       bool
+	omitempty      bool
+	string         bool
+	format         string
 }
 
 // parseFieldOptions parses the `json` tag in a Go struct field as
@@ -435,6 +436,7 @@ func parseFieldOptions(sf reflect.StructField) (out fieldOptions, ignored bool, 
 	}
 	b, _ := jsonwire.AppendQuote(nil, out.name, &jsonflags.Flags{})
 	out.quotedName = string(b)
+	out.nameNeedEscape = jsonwire.NeedEscape(out.name)
 
 	// Handle any additional tag options (if any).
 	var wasFormat bool

--- a/fields_test.go
+++ b/fields_test.go
@@ -217,7 +217,7 @@ func TestMakeStructFields(t *testing.T) {
 		}{},
 		want: structFields{
 			flattened: []structField{
-				{id: 0, index: []int{0}, typ: stringType, fieldOptions: fieldOptions{hasName: true, name: "\u07ad\ufffd\ufffd", quotedName: "\"\u07ad\ufffd\ufffd\""}},
+				{id: 0, index: []int{0}, typ: stringType, fieldOptions: fieldOptions{hasName: true, name: "\u07ad\ufffd\ufffd", quotedName: "\"\u07ad\ufffd\ufffd\"", nameNeedEscape: true}},
 			},
 		},
 		wantErr: errors.New(`Go struct field Name has JSON object name "ޭ\xbe\xef" with invalid UTF-8`),
@@ -574,13 +574,13 @@ func TestParseTagOptions(t *testing.T) {
 		in: struct {
 			V string `json:"!#$%&()*+-./:;<=>?@[]^_{|}~ "`
 		}{},
-		wantOpts: fieldOptions{hasName: true, name: "!#$%&()*+-./:;<=>?@[]^_{|}~ ", quotedName: `"!#$%&()*+-./:;<=>?@[]^_{|}~ "`},
+		wantOpts: fieldOptions{hasName: true, name: "!#$%&()*+-./:;<=>?@[]^_{|}~ ", quotedName: `"!#$%&()*+-./:;<=>?@[]^_{|}~ "`, nameNeedEscape: true},
 	}, {
 		name: jsontest.Name("QuotedPunctuationName"),
 		in: struct {
 			V string `json:"'!#$%&()*+-./:;<=>?@[]^_{|}~ '"`
 		}{},
-		wantOpts: fieldOptions{hasName: true, name: "!#$%&()*+-./:;<=>?@[]^_{|}~ ", quotedName: `"!#$%&()*+-./:;<=>?@[]^_{|}~ "`},
+		wantOpts: fieldOptions{hasName: true, name: "!#$%&()*+-./:;<=>?@[]^_{|}~ ", quotedName: `"!#$%&()*+-./:;<=>?@[]^_{|}~ "`, nameNeedEscape: true},
 	}, {
 		name: jsontest.Name("EmptyName"),
 		in: struct {
@@ -598,7 +598,7 @@ func TestParseTagOptions(t *testing.T) {
 		in: struct {
 			V int `json:"',\\'\"\\\"'"`
 		}{},
-		wantOpts: fieldOptions{hasName: true, name: `,'""`, quotedName: `",'\"\""`},
+		wantOpts: fieldOptions{hasName: true, name: `,'""`, quotedName: `",'\"\""`, nameNeedEscape: true},
 	}, {
 		name: jsontest.Name("SingleComma"),
 		in: struct {


### PR DESCRIPTION
By default, v1 always specifies EscapeForHTML and EscapeForJS, which prevents the optimization where the pre-quoted name is directly copied to the output buffer.

However, a vast majority of names never have characters that need to be escaped, so pre-compute whether escaping is necessary once within makeStructFields and use the precomputed result. Thus, we speed up marshaling on v1, which has taken a hit in performance when going through the v1in2 emulation.

Performance:

	name                                       old time/op    new time/op    delta
	Testdata/CitmCatalog/Marshal/Concrete      1.03ms ± 0%    0.92ms ± 1%  -10.94%  (p=0.008 n=5+5)
	Testdata/GolangSource/Marshal/Concrete     3.55ms ± 1%    3.20ms ± 2%   -9.88%  (p=0.008 n=5+5)
	Testdata/TwitterStatus/Marshal/Concrete     721µs ± 1%     593µs ± 1%  -17.78%  (p=0.008 n=5+5)