### PR TITLE
Optimize indexing of struct fields

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -1045,9 +1045,9 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 		xe.Tokens.Last.DisableNamespace() // we manually ensure unique names below
 		for i := range fields.flattened {
 			f := &fields.flattened[i]
-			v := addressableValue{va.Field(f.index[0]), va.forcedAddr} // addressable if struct value is addressable
-			if len(f.index) > 1 {
-				v = v.fieldByIndex(f.index[1:], false)
+			v := addressableValue{va.Field(f.index0), va.forcedAddr} // addressable if struct value is addressable
+			if len(f.index) > 0 {
+				v = v.fieldByIndex(f.index, false)
 				if !v.IsValid() {
 					continue // implies a nil inlined field
 				}
@@ -1282,9 +1282,9 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 					uo.FormatDepth = xd.Tokens.Depth()
 					uo.Format = f.format
 				}
-				v := addressableValue{va.Field(f.index[0]), va.forcedAddr} // addressable if struct value is addressable
-				if len(f.index) > 1 {
-					v = v.fieldByIndex(f.index[1:], true)
+				v := addressableValue{va.Field(f.index0), va.forcedAddr} // addressable if struct value is addressable
+				if len(f.index) > 0 {
+					v = v.fieldByIndex(f.index, true)
 					if !v.IsValid() {
 						err := newUnmarshalErrorBefore(dec, t, errNilField)
 						if !uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {

--- a/arshal_inlined.go
+++ b/arshal_inlined.go
@@ -35,9 +35,9 @@ var jsontextValueType = reflect.TypeFor[jsontext.Value]()
 
 // marshalInlinedFallbackAll marshals all the members in an inlined fallback.
 func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct, f *structField, insertUnquotedName func([]byte) bool) error {
-	v := addressableValue{va.Field(f.index[0]), va.forcedAddr} // addressable if struct value is addressable
-	if len(f.index) > 1 {
-		v = v.fieldByIndex(f.index[1:], false)
+	v := addressableValue{va.Field(f.index0), va.forcedAddr} // addressable if struct value is addressable
+	if len(f.index) > 0 {
+		v = v.fieldByIndex(f.index, false)
 		if !v.IsValid() {
 			return nil // implies a nil inlined field
 		}
@@ -165,9 +165,9 @@ func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *j
 
 // unmarshalInlinedFallbackNext unmarshals only the next member in an inlined fallback.
 func unmarshalInlinedFallbackNext(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct, f *structField, quotedName, unquotedName []byte) error {
-	v := addressableValue{va.Field(f.index[0]), va.forcedAddr} // addressable if struct value is addressable
-	if len(f.index) > 1 {
-		v = v.fieldByIndex(f.index[1:], true)
+	v := addressableValue{va.Field(f.index0), va.forcedAddr} // addressable if struct value is addressable
+	if len(f.index) > 0 {
+		v = v.fieldByIndex(f.index, true)
 	}
 	v = v.indirect(true)
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -515,7 +515,7 @@ func runEncode(t testing.TB, typeName, modeName string, buffer, data []byte, tok
 }
 
 func runDecode(t testing.TB, typeName, modeName string, buffer, data []byte, tokens []jsontext.Token) {
-	if strings.HasPrefix(benchVersion, "v1") && modeName == "Buffered " {
+	if strings.HasPrefix(benchVersion, "v1") && modeName == "Buffered" {
 		t.Skip("no support for direct buffered input in v1; see https://go.dev/issue/11046")
 	}
 

--- a/fields_test.go
+++ b/fields_test.go
@@ -420,6 +420,7 @@ func TestMakeStructFields(t *testing.T) {
 				gotErr = err.Err
 			}
 
+			tt.want.reindex()
 			if !reflect.DeepEqual(got, tt.want) || !reflect.DeepEqual(gotErr, tt.wantErr) {
 				t.Errorf("%s: makeStructFields(%T):\n\tgot  (%v, %v)\n\twant (%v, %v)", tt.name.Where, tt.in, got, gotErr, tt.want, tt.wantErr)
 			}


### PR DESCRIPTION
In order to index into struct fields, we always did:

    v := addressableValue{va.Field(f.index[0]), va.forcedAddr}
    if len(f.index) > 1 {
            v = v.fieldByIndex(f.index[1:], false)
            ...
    }

but this led to two implicit bounds check for

    f.index[0]
    f.index[1:]

since the compiler cannot prove that the f.index is a non-empty slice. This also results in implicit calls to runtime.panicIndex even though this can never happen based on how makeStructFields works.

Instead, have makeStructFields precompute an index0 field which contains the initial field indexing that must always happen, and pre-compute the result of f.index[1:].
Thus, the runtime logic never needs to do these computations. This saves on both runtime performance and binary size.

For example, makeStructArshaler.func6 went from 3756 to 3741 bytes and dropped 2 calls to runtime.panicSlice.

Performance:

    name                                           old time/op    new time/op    delta
    Testdata/CanadaGeometry/Marshal/Concrete        923µs ± 1%     904µs ± 1%  -2.08%  (p=0.008 n=5+5)
    Testdata/CanadaGeometry/Unmarshal/Concrete     1.22ms ± 0%    1.21ms ± 0%  -0.90%  (p=0.008 n=5+5)
    Testdata/CitmCatalog/Marshal/Concrete           891µs ± 1%     855µs ± 1%  -4.06%  (p=0.008 n=5+5)
    Testdata/CitmCatalog/Unmarshal/Concrete        2.02ms ± 0%    1.98ms ± 1%  -1.80%  (p=0.008 n=5+5)
    Testdata/GolangSource/Marshal/Concrete         3.34ms ± 1%    3.16ms ± 2%  -5.46%  (p=0.008 n=5+5)
    Testdata/GolangSource/Unmarshal/Concrete       5.65ms ± 1%    5.43ms ± 1%  -3.81%  (p=0.008 n=5+5)
    Testdata/StringEscaped/Marshal/Concrete        16.3µs ± 2%    15.6µs ± 0%  -4.34%  (p=0.008 n=5+5)
    Testdata/StringEscaped/Unmarshal/Concrete       159µs ± 2%     155µs ± 1%  -2.32%  (p=0.008 n=5+5)
    Testdata/StringUnicode/Marshal/Concrete        15.8µs ± 1%    15.6µs ± 1%  -1.35%  (p=0.032 n=5+5)
    Testdata/StringUnicode/Unmarshal/Concrete      20.6µs ± 1%    20.4µs ± 1%  -1.09%  (p=0.032 n=5+5)
    Testdata/SyntheaFhir/Marshal/Concrete          5.70ms ± 1%    5.52ms ± 1%  -3.29%  (p=0.008 n=5+5)
    Testdata/SyntheaFhir/Unmarshal/Concrete        3.56ms ± 1%    3.54ms ± 1%    ~     (p=0.056 n=5+5)
    Testdata/TwitterStatus/Marshal/Concrete         591µs ± 0%     591µs ± 0%    ~     (p=1.000 n=5+5)
    Testdata/TwitterStatus/Unmarshal/Concrete      1.13ms ± 1%    1.15ms ± 1%  +2.16%  (p=0.008 n=5+5)