### PR TITLE
Combine `nocase` and `strictcase` tag options under a `case` option

### DIFF
--- a/arshal_test.go
+++ b/arshal_test.go
@@ -158,10 +158,10 @@ type (
 		Quote string `json:"'\"'"`
 	}
 	structNoCase struct {
-		Aaa  string `json:",strictcase"`
+		Aaa  string `json:",case:strict"`
 		AA_A string
-		AaA  string `json:",nocase"`
-		AAa  string `json:",nocase"`
+		AaA  string `json:",case:ignore"`
+		AAa  string `json:",case:ignore"`
 		AAA  string
 	}
 	structScalars struct {
@@ -476,17 +476,17 @@ type (
 		B int                 `json:",omitzero"`
 	}
 	structNoCaseInlineTextValue struct {
-		AAA  string         `json:",omitempty,strictcase"`
+		AAA  string         `json:",omitempty,case:strict"`
 		AA_b string         `json:",omitempty"`
-		AaA  string         `json:",omitempty,nocase"`
-		AAa  string         `json:",omitempty,nocase"`
+		AaA  string         `json:",omitempty,case:ignore"`
+		AAa  string         `json:",omitempty,case:ignore"`
 		Aaa  string         `json:",omitempty"`
 		X    jsontext.Value `json:",inline"`
 	}
 	structNoCaseInlineMapStringAny struct {
 		AAA string     `json:",omitempty"`
-		AaA string     `json:",omitempty,nocase"`
-		AAa string     `json:",omitempty,nocase"`
+		AaA string     `json:",omitempty,case:ignore"`
+		AAa string     `json:",omitempty,case:ignore"`
 		Aaa string     `json:",omitempty"`
 		X   jsonObject `json:",inline"`
 	}

--- a/doc.go
+++ b/doc.go
@@ -88,19 +88,15 @@
 //     This extra level of encoding is often necessary since
 //     many JSON parsers cannot precisely represent 64-bit integers.
 //
-//   - nocase: When unmarshaling, the "nocase" option specifies that
-//     if the JSON object name does not exactly match the JSON name
-//     for any of the struct fields, then it attempts to match the struct field
-//     using a case-insensitive match that also ignores dashes and underscores.
-//     If multiple fields match,
+//   - case: When unmarshaling, the "case" option specifies how
+//     JSON object names are matched with the JSON name for Go struct fields.
+//     The option is a key-value pair specified as "case:value" where
+//     the value must either be 'ignore' or 'strict'.
+//     The 'ignore' value specifies that matching is case-insensitive
+//     where dashes and underscores are also ignored. If multiple fields match,
 //     the first declared field in breadth-first order takes precedence.
-//     This takes precedence even if [MatchCaseInsensitiveNames] is set to false.
-//     This cannot be specified together with the "strictcase" option.
-//
-//   - strictcase: When unmarshaling, the "strictcase" option specifies that the
-//     JSON object name must exactly match the JSON name for the struct field.
-//     This takes precedence even if [MatchCaseInsensitiveNames] is set to true.
-//     This cannot be specified together with the "nocase" option.
+//     The 'strict' value specifies that matching is case-sensitive.
+//     This takes precedence over the [MatchCaseInsensitiveNames] option.
 //
 //   - inline: The "inline" option specifies that
 //     the JSON representable content of this field type is to be promoted

--- a/example_test.go
+++ b/example_test.go
@@ -74,7 +74,7 @@ func Example_fieldNames() {
 		// A JSON name is provided without any special characters.
 		JSONName any `json:"jsonName"`
 		// No JSON name is not provided, so the Go field name is used.
-		Option any `json:",nocase"`
+		Option any `json:",case:ignore"`
 		// An empty JSON name specified using an single-quoted string literal.
 		Empty any `json:"''"`
 		// A dash JSON name specified using an single-quoted string literal.
@@ -108,8 +108,8 @@ func Example_fieldNames() {
 
 // Unmarshal matches JSON object names with Go struct fields using
 // a case-sensitive match, but can be configured to use a case-insensitive
-// match with the "nocase" option. This permits unmarshaling from inputs that
-// use naming conventions such as camelCase, snake_case, or kebab-case.
+// match with the "case:ignore" option. This permits unmarshaling from inputs
+// that use naming conventions such as camelCase, snake_case, or kebab-case.
 func Example_caseSensitivity() {
 	// JSON input using various naming conventions.
 	const input = `[
@@ -124,24 +124,24 @@ func Example_caseSensitivity() {
 		{"unknown": true}
 	]`
 
-	// Without "nocase", Unmarshal looks for an exact match.
-	var withcase []struct {
+	// Without "case:ignore", Unmarshal looks for an exact match.
+	var caseStrict []struct {
 		X bool `json:"firstName"`
 	}
-	if err := json.Unmarshal([]byte(input), &withcase); err != nil {
+	if err := json.Unmarshal([]byte(input), &caseStrict); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(withcase) // exactly 1 match found
+	fmt.Println(caseStrict) // exactly 1 match found
 
-	// With "nocase", Unmarshal looks first for an exact match,
+	// With "case:ignore", Unmarshal looks first for an exact match,
 	// then for a case-insensitive match if none found.
-	var nocase []struct {
-		X bool `json:"firstName,nocase"`
+	var caseIgnore []struct {
+		X bool `json:"firstName,case:ignore"`
 	}
-	if err := json.Unmarshal([]byte(input), &nocase); err != nil {
+	if err := json.Unmarshal([]byte(input), &caseIgnore); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(nocase) // 8 matches found
+	fmt.Println(caseIgnore) // 8 matches found
 
 	// Output:
 	// [{false} {true} {false} {false} {false} {false} {false} {false} {false}]

--- a/fold_test.go
+++ b/fold_test.go
@@ -111,7 +111,7 @@ func TestBenchmarkUnmarshalUnknown(t *testing.T) {
 			fields = append(fields, reflect.StructField{
 				Name: fmt.Sprintf("Name%d", i),
 				Type: T[int](),
-				Tag:  `json:",nocase"`,
+				Tag:  `json:",case:ignore"`,
 			})
 		}
 		out := reflect.New(reflect.StructOf(fields)).Interface()

--- a/options.go
+++ b/options.go
@@ -185,7 +185,7 @@ func OmitZeroStructFields(v bool) Options {
 
 // MatchCaseInsensitiveNames specifies that JSON object members are matched
 // against Go struct fields using a case-insensitive match of the name.
-// Go struct fields explicitly marked with `strictcase` or `nocase`
+// Go struct fields explicitly marked with `case:strict` or `case:ignore`
 // always use case-sensitive (or case-insensitive) name matching,
 // regardless of the value of this option.
 //

--- a/v1/diff_test.go
+++ b/v1/diff_test.go
@@ -37,7 +37,7 @@ var jsonPackages = []struct {
 //
 // Case-insensitive matching is a surprising default and
 // incurs significant performance cost when unmarshaling unknown fields.
-// In v2, we can opt into v1-like behavior with the `nocase` tag option.
+// In v2, we can opt into v1-like behavior with the `case:ignore` tag option.
 // The case-insensitive matching performed by v2 is looser than that of v1
 // where it also ignores dashes and underscores.
 // This allows v2 to match fields regardless of whether the name is in
@@ -50,7 +50,7 @@ func TestCaseSensitivity(t *testing.T) {
 	type Fields struct {
 		FieldA bool
 		FieldB bool `json:"fooBar"`
-		FieldC bool `json:"fizzBuzz,nocase"` // `nocase` is used by v2 to explicitly enable case-insensitive matching
+		FieldC bool `json:"fizzBuzz,case:ignore"` // `case:ignore` is used by v2 to explicitly enable case-insensitive matching
 	}
 
 	for _, json := range jsonPackages {
@@ -82,8 +82,8 @@ func TestCaseSensitivity(t *testing.T) {
 				},
 				"FieldC": {
 					"fizzBuzz":  true,   // exact match for explicitly specified JSON name
-					"fizzbuzz":  true,   // v2 is case-insensitive due to `nocase` tag
-					"FIZZBUZZ":  true,   // v2 is case-insensitive due to `nocase` tag
+					"fizzbuzz":  true,   // v2 is case-insensitive due to `case:ignore` tag
+					"FIZZBUZZ":  true,   // v2 is case-insensitive due to `case:ignore` tag
 					"fizz_buzz": onlyV2, // case-insensitivity in v2 ignores dashes and underscores
 					"fizz-buzz": onlyV2, // case-insensitivity in v2 ignores dashes and underscores
 					"fooBar":    false,

--- a/v1/options.go
+++ b/v1/options.go
@@ -24,8 +24,8 @@
 //     In contrast, v2 matches fields using an exact, case-sensitive match.
 //     The [jsonv2.MatchCaseInsensitiveNames] and [MatchCaseSensitiveDelimiter]
 //     options control this behavior difference. To explicitly specify a Go struct
-//     field to use a particular name matching scheme, either the `nocase`
-//     or the `strictcase` field option can be specified.
+//     field to use a particular name matching scheme, either the `case:ignore`
+//     or the `case:strict` field option can be specified.
 //     Field-specified options take precedence over caller-specified options.
 //
 //   - In v1, when marshaling a Go struct, a field marked as `omitempty`
@@ -358,7 +358,7 @@ func FormatTimeWithLegacySemantics(v bool) Options {
 
 // MatchCaseSensitiveDelimiter specifies that underscores and dashes are
 // not to be ignored when performing case-insensitive name matching which
-// occurs under [jsonv2.MatchCaseInsensitiveNames] or the `nocase` tag option.
+// occurs under [jsonv2.MatchCaseInsensitiveNames] or the `case:ignore` tag option.
 // Thus, case-insensitive name matching is identical to [strings.EqualFold].
 // Use of this option diminishes the ability of case-insensitive matching
 // to be able to match common case variants (e.g, "foo_bar" with "fooBar").


### PR DESCRIPTION
WARNING: This commit contains breaking changes.

Instead of specifying `nocase` or `strictcase` tag options, use a single `case` tag option, which is a key-value pair where the value can only be 'ignore' or 'strict'.
This reads more naturally as `case:ignore` or `case:strict` and is more clear that `case:ignore` and `case:strict` are mutually exclusive tag options.