### PR TITLE
Use newer encoding.TextAppender interface in Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Test
@@ -26,7 +26,7 @@ jobs:
   test-all:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/arshal.go
+++ b/arshal.go
@@ -6,16 +6,28 @@ package json
 
 import (
 	"bytes"
+	"encoding"
 	"io"
 	"reflect"
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-json-experiment/json/internal"
 	"github.com/go-json-experiment/json/internal/jsonflags"
 	"github.com/go-json-experiment/json/internal/jsonopts"
 	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Reference encoding and time packages to assist pkgsite
+// in being able to hotlink references to those packages.
+var (
+	_ encoding.TextMarshaler
+	_ encoding.TextAppender
+	_ encoding.TextUnmarshaler
+	_ time.Time
+	_ time.Duration
 )
 
 // export exposes internal functionality of the "jsontext" package.
@@ -76,6 +88,10 @@ func putStructOptions(o *jsonopts.Struct) {
 //
 //   - If the value type implements [Marshaler],
 //     then the MarshalJSON method is called to encode the value.
+//
+//   - If the value type implements [encoding.TextAppender],
+//     then the AppendText method is called to encode the value and
+//     subsequently encode its result as a JSON string.
 //
 //   - If the value type implements [encoding.TextMarshaler],
 //     then the MarshalText method is called to encode the value and

--- a/arshal_default.go
+++ b/arshal_default.go
@@ -1720,7 +1720,7 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 				case jsonMarshalerType:
 					v2.Set(reflect.ValueOf(struct{ Marshaler }{va.Elem().Interface().(Marshaler)}))
 				case textAppenderType:
-					v2.Set(reflect.ValueOf(struct{ encodingTextAppender }{va.Elem().Interface().(encodingTextAppender)}))
+					v2.Set(reflect.ValueOf(struct{ encoding.TextAppender }{va.Elem().Interface().(encoding.TextAppender)}))
 				case textMarshalerType:
 					v2.Set(reflect.ValueOf(struct{ encoding.TextMarshaler }{va.Elem().Interface().(encoding.TextMarshaler)}))
 				}

--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -24,25 +24,14 @@ var (
 	jsonMarshalerToType     = reflect.TypeFor[MarshalerTo]()
 	jsonUnmarshalerType     = reflect.TypeFor[Unmarshaler]()
 	jsonUnmarshalerFromType = reflect.TypeFor[UnmarshalerFrom]()
-	textAppenderType        = reflect.TypeFor[encodingTextAppender]()
+	textAppenderType        = reflect.TypeFor[encoding.TextAppender]()
 	textMarshalerType       = reflect.TypeFor[encoding.TextMarshaler]()
 	textUnmarshalerType     = reflect.TypeFor[encoding.TextUnmarshaler]()
-
-	// TODO(https://go.dev/issue/62384): Use encoding.TextAppender instead of this hack.
-	// This exists for now to provide performance benefits to netip types.
-	// There is no semantic difference with this change.
-	appenderToType = reflect.TypeFor[interface{ AppendTo([]byte) []byte }]()
 
 	allMarshalerTypes   = []reflect.Type{jsonMarshalerToType, jsonMarshalerType, textAppenderType, textMarshalerType}
 	allUnmarshalerTypes = []reflect.Type{jsonUnmarshalerFromType, jsonUnmarshalerType, textUnmarshalerType}
 	allMethodTypes      = append(allMarshalerTypes, allUnmarshalerTypes...)
 )
-
-// TODO(https://go.dev/issue/62384): Use encoding.TextAppender instead
-// and document public support for this method in json.Marshal.
-type encodingTextAppender interface {
-	AppendText(b []byte) ([]byte, error)
-}
 
 // Marshaler is implemented by types that can marshal themselves.
 // It is recommended that types implement [MarshalerTo] unless the implementation
@@ -137,21 +126,6 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			}
 			return nil
 		}
-		// TODO(https://go.dev/issue/62384): Rely on encoding.TextAppender instead.
-		if implementsAny(t, appenderToType) && t.PkgPath() == "net/netip" {
-			fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
-				appender := va.Addr().Interface().(interface{ AppendTo([]byte) []byte })
-				if err := export.Encoder(enc).AppendRaw('"', false, func(b []byte) ([]byte, error) {
-					return appender.AppendTo(b), nil
-				}); err != nil {
-					if !isSemanticError(err) && !export.IsIOError(err) {
-						err = newMarshalErrorBefore(enc, t, err)
-					}
-					return err
-				}
-				return nil
-			}
-		}
 	}
 
 	if needAddr, ok := implements(t, textAppenderType); ok {
@@ -162,7 +136,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				(needAddr && va.forcedAddr) {
 				return prevMarshal(enc, va, mo)
 			}
-			appender := va.Addr().Interface().(encodingTextAppender)
+			appender := va.Addr().Interface().(encoding.TextAppender)
 			if err := export.Encoder(enc).AppendRaw('"', false, appender.AppendText); err != nil {
 				err = wrapSkipFunc(err, "append method")
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {

--- a/fields_test.go
+++ b/fields_test.go
@@ -273,9 +273,17 @@ func TestMakeStructFields(t *testing.T) {
 	}, {
 		name: jsontest.Name("InlineTextAppender"),
 		in: struct {
-			A struct{ encodingTextAppender } `json:",inline"`
+			A struct{ encoding.TextAppender } `json:",inline"`
 		}{},
-		wantErr: errors.New(`inlined Go struct field A of type struct { json.encodingTextAppender } must not implement marshal or unmarshal methods`),
+		want: structFields{flattened: []structField{{
+			index: []int{0, 0},
+			typ:   reflect.TypeFor[encoding.TextAppender](),
+			fieldOptions: fieldOptions{
+				name:       "TextAppender",
+				quotedName: `"TextAppender"`,
+			},
+		}}},
+		wantErr: errors.New(`inlined Go struct field A of type struct { encoding.TextAppender } must not implement marshal or unmarshal methods`),
 	}, {
 		name: jsontest.Name("UnknownJSONMarshaler"),
 		in: struct {

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,4 @@
 // This package will regularly experience breaking changes.
 module github.com/go-json-experiment/json
 
-go 1.23
+go 1.24

--- a/v1/options.go
+++ b/v1/options.go
@@ -179,12 +179,13 @@ import (
 	"github.com/go-json-experiment/json/jsontext"
 )
 
-// Reference the jsonv2 and jsontext packages to assist pkgsite
-// in being able to hotlink  references to those packages.
+// Reference encoding, jsonv2, and jsontext packages to assist pkgsite
+// in being able to hotlink references to those packages.
 var (
-	_ = jsonv2.Deterministic
-	_ = jsontext.AllowDuplicateNames
-	_ = encoding.TextMarshaler(nil)
+	_ encoding.TextMarshaler
+	_ encoding.TextUnmarshaler
+	_ jsonv2.Options
+	_ jsontext.Options
 )
 
 // Options are a set of options to configure the v2 "json" package


### PR DESCRIPTION
Also, remove special case for netip.Addr,
which now implements the encoding.TextAppender interface.