### PR TITLE
Drop Options argument from user-declared methods and functions

### DIFF
--- a/arshal_funcs.go
+++ b/arshal_funcs.go
@@ -209,9 +209,9 @@ func MarshalFunc[T any](fn func(T) ([]byte, error)) *Marshalers {
 // on the provided encoder. It may return [SkipFunc] such that marshaling can
 // move on to the next marshal function. However, no mutable method calls may
 // be called on the encoder if [SkipFunc] is returned.
-// The pointer to [jsontext.Encoder], the value of T, and the [Options] value
+// The pointer to [jsontext.Encoder] and the value of T
 // must not be retained outside the function call.
-func MarshalToFunc[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshalers {
+func MarshalToFunc[T any](fn func(*jsontext.Encoder, T) error) *Marshalers {
 	t := reflect.TypeFor[T]()
 	assertCastableTo(t, true)
 	typFnc := typedMarshaler{
@@ -220,7 +220,7 @@ func MarshalToFunc[T any](fn func(*jsontext.Encoder, T, Options) error) *Marshal
 			xe := export.Encoder(enc)
 			prevDepth, prevLength := xe.Tokens.DepthLength()
 			xe.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := fn(enc, va.castTo(t).Interface().(T), mo)
+			err := fn(enc, va.castTo(t).Interface().(T))
 			xe.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xe.Tokens.DepthLength()
 			if err == nil && (prevDepth != currDepth || prevLength+1 != currLength) {
@@ -291,9 +291,9 @@ func UnmarshalFunc[T any](fn func([]byte, T) error) *Unmarshalers {
 // on the provided decoder. It may return [SkipFunc] such that unmarshaling can
 // move on to the next unmarshal function. However, no mutable method calls may
 // be called on the decoder if [SkipFunc] is returned.
-// The pointer to [jsontext.Decoder], the value of T, and [Options] value
+// The pointer to [jsontext.Decoder] and the value of T
 // must not be retained outside the function call.
-func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T, Options) error) *Unmarshalers {
+func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T) error) *Unmarshalers {
 	t := reflect.TypeFor[T]()
 	assertCastableTo(t, false)
 	typFnc := typedUnmarshaler{
@@ -302,7 +302,7 @@ func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T, Options) error) *Unm
 			xd := export.Decoder(dec)
 			prevDepth, prevLength := xd.Tokens.DepthLength()
 			xd.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := fn(dec, va.castTo(t).Interface().(T), uo)
+			err := fn(dec, va.castTo(t).Interface().(T))
 			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xd.Tokens.DepthLength()
 			if err == nil && (prevDepth != currDepth || prevLength+1 != currLength) {

--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -51,9 +51,9 @@ type Marshaler interface {
 // should aim to have equivalent behavior for the default marshal options.
 //
 // The implementation must write only one JSON value to the Encoder and
-// must not retain the pointer to [jsontext.Encoder] or the [Options] value.
+// must not retain the pointer to [jsontext.Encoder].
 type MarshalerTo interface {
-	MarshalJSONTo(*jsontext.Encoder, Options) error
+	MarshalJSONTo(*jsontext.Encoder) error
 
 	// TODO: Should users call the MarshalEncode function or
 	// should/can they call this method directly? Does it matter?
@@ -85,10 +85,9 @@ type Unmarshaler interface {
 // It is recommended that UnmarshalJSONFrom implement merge semantics when
 // unmarshaling into a pre-populated value.
 //
-// Implementations must not retain the pointer to [jsontext.Decoder] or
-// the [Options] value.
+// Implementations must not retain the pointer to [jsontext.Decoder].
 type UnmarshalerFrom interface {
-	UnmarshalJSONFrom(*jsontext.Decoder, Options) error
+	UnmarshalJSONFrom(*jsontext.Decoder) error
 
 	// TODO: Should users call the UnmarshalDecode function or
 	// should/can they call this method directly? Does it matter?
@@ -193,7 +192,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			xe := export.Encoder(enc)
 			prevDepth, prevLength := xe.Tokens.DepthLength()
 			xe.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := va.Addr().Interface().(MarshalerTo).MarshalJSONTo(enc, mo)
+			err := va.Addr().Interface().(MarshalerTo).MarshalJSONTo(enc)
 			xe.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xe.Tokens.DepthLength()
 			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {
@@ -283,7 +282,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			xd := export.Decoder(dec)
 			prevDepth, prevLength := xd.Tokens.DepthLength()
 			xd.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := va.Addr().Interface().(UnmarshalerFrom).UnmarshalJSONFrom(dec, uo)
+			err := va.Addr().Interface().(UnmarshalerFrom).UnmarshalJSONFrom(dec)
 			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xd.Tokens.DepthLength()
 			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {

--- a/bench_test.go
+++ b/bench_test.go
@@ -303,10 +303,10 @@ func (*jsonArshalerV1) UnmarshalJSON(b []byte) error {
 
 type jsonArshalerV2 struct{ _ [4]int }
 
-func (jsonArshalerV2) MarshalJSONTo(enc *jsontext.Encoder, opts jsonv2.Options) error {
+func (jsonArshalerV2) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return enc.WriteToken(jsontext.String("method"))
 }
-func (*jsonArshalerV2) UnmarshalJSONFrom(dec *jsontext.Decoder, opts jsonv2.Options) error {
+func (*jsonArshalerV2) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	b, err := dec.ReadValue()
 	if string(b) != `"method"` {
 		return fmt.Errorf("UnmarshalJSONFrom: got %q, want %q", b, `"method"`)

--- a/example_orderedobject_test.go
+++ b/example_orderedobject_test.go
@@ -29,16 +29,16 @@ type ObjectMember[V any] struct {
 }
 
 // MarshalJSONTo encodes obj as a JSON object into enc.
-func (obj *OrderedObject[V]) MarshalJSONTo(enc *jsontext.Encoder, opts json.Options) error {
+func (obj *OrderedObject[V]) MarshalJSONTo(enc *jsontext.Encoder) error {
 	if err := enc.WriteToken(jsontext.BeginObject); err != nil {
 		return err
 	}
 	for i := range *obj {
 		member := &(*obj)[i]
-		if err := json.MarshalEncode(enc, &member.Name, opts); err != nil {
+		if err := json.MarshalEncode(enc, &member.Name); err != nil {
 			return err
 		}
-		if err := json.MarshalEncode(enc, &member.Value, opts); err != nil {
+		if err := json.MarshalEncode(enc, &member.Value); err != nil {
 			return err
 		}
 	}
@@ -49,7 +49,7 @@ func (obj *OrderedObject[V]) MarshalJSONTo(enc *jsontext.Encoder, opts json.Opti
 }
 
 // UnmarshalJSONFrom decodes a JSON object from dec into obj.
-func (obj *OrderedObject[V]) UnmarshalJSONFrom(dec *jsontext.Decoder, opts json.Options) error {
+func (obj *OrderedObject[V]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if k := dec.PeekKind(); k != '{' {
 		return fmt.Errorf("expected object start, but encountered %v", k)
 	}
@@ -59,10 +59,10 @@ func (obj *OrderedObject[V]) UnmarshalJSONFrom(dec *jsontext.Decoder, opts json.
 	for dec.PeekKind() != '}' {
 		*obj = append(*obj, ObjectMember[V]{})
 		member := &(*obj)[len(*obj)-1]
-		if err := json.UnmarshalDecode(dec, &member.Name, opts); err != nil {
+		if err := json.UnmarshalDecode(dec, &member.Name); err != nil {
 			return err
 		}
-		if err := json.UnmarshalDecode(dec, &member.Value, opts); err != nil {
+		if err := json.UnmarshalDecode(dec, &member.Value); err != nil {
 			return err
 		}
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -562,7 +562,7 @@ func ExampleWithMarshalers_errors() {
 			// Suppose we consider strconv.NumError to be a safe to serialize:
 			// this type-specific marshal function intercepts this type
 			// and encodes the error message as a JSON string.
-			json.MarshalToFunc(func(enc *jsontext.Encoder, err *strconv.NumError, opts json.Options) error {
+			json.MarshalToFunc(func(enc *jsontext.Encoder, err *strconv.NumError) error {
 				return enc.WriteToken(jsontext.String(err.Error()))
 			}),
 			// Error messages may contain sensitive information that may not
@@ -604,7 +604,7 @@ func ExampleWithUnmarshalers_rawNumber() {
 	err := json.Unmarshal([]byte(input), &value,
 		// Intercept every attempt to unmarshal into the any type.
 		json.WithUnmarshalers(
-			json.UnmarshalFromFunc(func(dec *jsontext.Decoder, val *any, opts json.Options) error {
+			json.UnmarshalFromFunc(func(dec *jsontext.Decoder, val *any) error {
 				// If the next value to be decoded is a JSON number,
 				// then provide a concrete Go type to unmarshal into.
 				if dec.PeekKind() == '0' {
@@ -652,7 +652,7 @@ func ExampleWithUnmarshalers_recordOffsets() {
 	err := json.Unmarshal([]byte(input), &tunnels,
 		// Intercept every attempt to unmarshal into the Tunnel type.
 		json.WithUnmarshalers(
-			json.UnmarshalFromFunc(func(dec *jsontext.Decoder, tunnel *Tunnel, opts json.Options) error {
+			json.UnmarshalFromFunc(func(dec *jsontext.Decoder, tunnel *Tunnel) error {
 				// Decoder.InputOffset reports the offset after the last token,
 				// but we want to record the offset before the next token.
 				//

--- a/jsontext/decode.go
+++ b/jsontext/decode.go
@@ -142,8 +142,21 @@ func (d *Decoder) Reset(r io.Reader, opts ...Options) {
 func (d *decoderState) reset(b []byte, r io.Reader, opts ...Options) {
 	d.state.reset()
 	d.decodeBuffer = decodeBuffer{buf: b, rd: r}
-	d.Struct = jsonopts.Struct{}
-	d.Struct.Join(opts...)
+	opts2 := jsonopts.Struct{} // avoid mutating d.Struct in case it is part of opts
+	opts2.Join(opts...)
+	d.Struct = opts2
+}
+
+// Options returns the options used to construct the encoder and
+// may additionally contain semantic options passed to a
+// [encoding/json/v2.UnmarshalDecode] call.
+//
+// If operating within
+// a [encoding/json/v2.UnmarshalerFrom.UnmarshalJSONFrom] method call or
+// a [encoding/json/v2.UnmarshalFromFunc] function call,
+// then the returned options are only valid within the call.
+func (d *Decoder) Options() Options {
+	return &d.s.Struct
 }
 
 var errBufferWriteAfterNext = errors.New("invalid bytes.Buffer.Write call after calling bytes.Buffer.Next")

--- a/options.go
+++ b/options.go
@@ -75,9 +75,7 @@ type Options = jsonopts.Options
 // Properties set in later options override the value of previously set properties.
 func JoinOptions(srcs ...Options) Options {
 	var dst jsonopts.Struct
-	for _, src := range srcs {
-		dst.Join(src)
-	}
+	dst.Join(srcs...)
 	return &dst
 }
 

--- a/v1/decode.go
+++ b/v1/decode.go
@@ -189,7 +189,8 @@ func (n Number) Int64() (int64, error) {
 var numberType = reflect.TypeFor[Number]()
 
 // MarshalJSONTo implements [jsonv2.MarshalerTo].
-func (n Number) MarshalJSONTo(enc *jsontext.Encoder, opts jsonv2.Options) error {
+func (n Number) MarshalJSONTo(enc *jsontext.Encoder) error {
+	opts := enc.Options()
 	stringify, _ := jsonv2.GetOption(opts, jsonv2.StringifyNumbers)
 	if k, n := enc.StackIndex(enc.StackDepth()); k == '{' && n%2 == 0 {
 		stringify = true // expecting a JSON object name
@@ -213,7 +214,8 @@ func (n Number) MarshalJSONTo(enc *jsontext.Encoder, opts jsonv2.Options) error 
 }
 
 // UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
-func (n *Number) UnmarshalJSONFrom(dec *jsontext.Decoder, opts jsonv2.Options) error {
+func (n *Number) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	opts := dec.Options()
 	stringify, _ := jsonv2.GetOption(opts, jsonv2.StringifyNumbers)
 	if k, n := dec.StackIndex(dec.StackDepth()); k == '{' && n%2 == 0 {
 		stringify = true // expecting a JSON object name


### PR DESCRIPTION
WARNING: This commit contains breaking changes.

This drops Options as an argument from
the MarshalerTo and UnmarshalerFrom interfaces and the MarshalToFunc and UnmarshalFromFunc functions.

Instead, the options is stored within the
jsontext.Encoder or jsontext.Decoder and
can be retrieved through the Options method.

This simplifies the API for custom marshalers and unmarshalers and makes it impossible to accidentally drop the options when recursively calling json.MarshalEncode or json.UnmarshalDecode from within a custom marshaler or unmarshaler implementation.

Fixes golang/go#71611