### PR TITLE
jsontext: Preserve the internal buffer between Reset calls

### DIFF
--- a/jsontext/decode.go
+++ b/jsontext/decode.go
@@ -136,7 +136,7 @@ func (d *Decoder) Reset(r io.Reader, opts ...Options) {
 	case d.s.Flags.Get(jsonflags.WithinArshalCall):
 		panic("jsontext: cannot reset Decoder passed to json.UnmarshalerFrom")
 	}
-	d.s.reset(nil, r, opts...)
+	d.s.reset(d.s.buf[:0], r, opts...)
 }
 
 func (d *decoderState) reset(b []byte, r io.Reader, opts ...Options) {


### PR DESCRIPTION
The jsontext decoder throws away the internal buffer on each Reset call. This makes decoding one message at a time pretty wasteful since each new message will cause at least one allocation for the buffer.

This commit makes sure the buffer gets reused when the decoder is reset with a new reader. If unbounded growth for the slice is a concern, I can add an option limiting the maxiumum size after which the bytes buffer will be thrown away and a new one can be allocated.