### PR TITLE
Update to 86fca3dcb63157b8e45e565e821e7fb098fcf368

### DIFF
--- a/internal/jsonopts/options.go
+++ b/internal/jsonopts/options.go
@@ -63,7 +63,7 @@ func (*Struct) JSONOptions(internal.NotForPublicUse) {}
 
 // GetUnknownOption is injected by the "json" package to handle Options
 // declared in that package so that "jsonopts" can handle them.
-var GetUnknownOption = func(*Struct, Options) (any, bool) { panic("unknown option") }
+var GetUnknownOption = func(Struct, Options) (any, bool) { panic("unknown option") }
 
 func GetOption[T any](opts Options, setter func(T) Options) (T, bool) {
 	// Collapse the options to *Struct to simplify lookup.
@@ -102,14 +102,14 @@ func GetOption[T any](opts Options, setter func(T) Options) (T, bool) {
 		}
 		return any(structOpts.DepthLimit).(T), true
 	default:
-		v, ok := GetUnknownOption(structOpts, opt)
+		v, ok := GetUnknownOption(*structOpts, opt)
 		return v.(T), ok
 	}
 }
 
 // JoinUnknownOption is injected by the "json" package to handle Options
 // declared in that package so that "jsonopts" can handle them.
-var JoinUnknownOption = func(*Struct, Options) { panic("unknown option") }
+var JoinUnknownOption = func(Struct, Options) Struct { panic("unknown option") }
 
 func (dst *Struct) Join(srcs ...Options) {
 	dst.join(false, srcs...)
@@ -180,7 +180,7 @@ func (dst *Struct) join(excludeCoderOptions bool, srcs ...Options) {
 				}
 			}
 		default:
-			JoinUnknownOption(dst, src)
+			*dst = JoinUnknownOption(*dst, src)
 		}
 	}
 }

--- a/jsontext/encode.go
+++ b/jsontext/encode.go
@@ -112,7 +112,7 @@ func (e *encoderState) reset(b []byte, w io.Writer, opts ...Options) {
 	e.state.reset()
 	e.encodeBuffer = encodeBuffer{Buf: b, wr: w, bufStats: e.bufStats}
 	if bb, ok := w.(*bytes.Buffer); ok && bb != nil {
-		e.Buf = bb.Bytes()[bb.Len():] // alias the unused buffer of bb
+		e.Buf = bb.AvailableBuffer() // alias the unused buffer of bb
 	}
 	opts2 := jsonopts.Struct{} // avoid mutating e.Struct in case it is part of opts
 	opts2.Join(opts...)

--- a/options.go
+++ b/options.go
@@ -255,7 +255,7 @@ func (*unmarshalersOption) JSONOptions(internal.NotForPublicUse) {}
 
 // Inject support into "jsonopts" to handle these types.
 func init() {
-	jsonopts.GetUnknownOption = func(src *jsonopts.Struct, zero jsonopts.Options) (any, bool) {
+	jsonopts.GetUnknownOption = func(src jsonopts.Struct, zero jsonopts.Options) (any, bool) {
 		switch zero.(type) {
 		case *marshalersOption:
 			if !src.Flags.Has(jsonflags.Marshalers) {
@@ -271,7 +271,7 @@ func init() {
 			panic(fmt.Sprintf("unknown option %T", zero))
 		}
 	}
-	jsonopts.JoinUnknownOption = func(dst *jsonopts.Struct, src jsonopts.Options) {
+	jsonopts.JoinUnknownOption = func(dst jsonopts.Struct, src jsonopts.Options) jsonopts.Struct {
 		switch src := src.(type) {
 		case *marshalersOption:
 			dst.Flags.Set(jsonflags.Marshalers | 1)
@@ -282,5 +282,6 @@ func init() {
 		default:
 			panic(fmt.Sprintf("unknown option %T", src))
 		}
+		return dst
 	}
 }

--- a/v1/options.go
+++ b/v1/options.go
@@ -219,7 +219,7 @@ type Options = jsonopts.Options
 //   - [jsontext.AllowInvalidUTF8]
 //   - [jsontext.EscapeForHTML]
 //   - [jsontext.EscapeForJS]
-//   - [jsontext.PreserveRawString]
+//   - [jsontext.PreserveRawStrings]
 //
 // All other boolean options are set to false.
 // All non-boolean options are set to the zero value,


### PR DESCRIPTION
This pulls in the following changes:
* (https://go.dev/cl/684416) encoding/json: fix typo in hotlink for jsontext.PreserveRawStrings
* (https://go.dev/cl/685135) encoding/json/v2: avoid escaping jsonopts.Struct
* (https://go.dev/cl/685136) encoding/json/jsontext: use bytes.Buffer.AvailableBuffer