### PR TITLE
Update to 9159cd4ec6b0e9475dc9c71c830035c1c4c13483

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -436,7 +436,8 @@ func unmarshalFull(in *jsontext.Decoder, out any, uo *jsonopts.Struct) error {
 	case nil:
 		return export.Decoder(in).CheckEOF()
 	case io.EOF:
-		return io.ErrUnexpectedEOF
+		offset := in.InputOffset() + int64(len(in.UnreadBuffer()))
+		return &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
 	default:
 		return err
 	}

--- a/arshal_default.go
+++ b/arshal_default.go
@@ -327,8 +327,9 @@ func makeBytesArshaler(t reflect.Type, fncs *arshaler) *arshaler {
 			default:
 				return newInvalidFormatError(enc, t, mo)
 			}
-		} else if mo.Flags.Get(jsonflags.FormatBytesWithLegacySemantics) &&
-			(va.Kind() == reflect.Array || hasMarshaler) {
+		} else if mo.Flags.Get(jsonflags.FormatByteArrayAsArray) && va.Kind() == reflect.Array {
+			return marshalArray(enc, va, mo)
+		} else if mo.Flags.Get(jsonflags.FormatBytesWithLegacySemantics) && hasMarshaler {
 			return marshalArray(enc, va, mo)
 		}
 		if mo.Flags.Get(jsonflags.FormatNilSliceAsNull) && va.Kind() == reflect.Slice && va.IsNil() {
@@ -364,8 +365,9 @@ func makeBytesArshaler(t reflect.Type, fncs *arshaler) *arshaler {
 			default:
 				return newInvalidFormatError(dec, t, uo)
 			}
-		} else if uo.Flags.Get(jsonflags.FormatBytesWithLegacySemantics) &&
-			(va.Kind() == reflect.Array || dec.PeekKind() == '[') {
+		} else if uo.Flags.Get(jsonflags.FormatByteArrayAsArray) && va.Kind() == reflect.Array {
+			return unmarshalArray(dec, va, uo)
+		} else if uo.Flags.Get(jsonflags.FormatBytesWithLegacySemantics) && dec.PeekKind() == '[' {
 			return unmarshalArray(dec, va, uo)
 		}
 		var flags jsonwire.ValueFlags
@@ -393,7 +395,7 @@ func makeBytesArshaler(t reflect.Type, fncs *arshaler) *arshaler {
 			if err != nil {
 				return newUnmarshalErrorAfter(dec, t, err)
 			}
-			if len(val) != encodedLen(len(b)) && !uo.Flags.Get(jsonflags.FormatBytesWithLegacySemantics) {
+			if len(val) != encodedLen(len(b)) && !uo.Flags.Get(jsonflags.ParseBytesWithLooseRFC4648) {
 				// TODO(https://go.dev/issue/53845): RFC 4648, section 3.3,
 				// specifies that non-alphabet characters must be rejected.
 				// Unfortunately, the "base32" and "base64" packages allow
@@ -1063,7 +1065,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 			}
 
 			// Check for the legacy definition of omitempty.
-			if f.omitempty && mo.Flags.Get(jsonflags.OmitEmptyWithLegacyDefinition) && isLegacyEmpty(v) {
+			if f.omitempty && mo.Flags.Get(jsonflags.OmitEmptyWithLegacySemantics) && isLegacyEmpty(v) {
 				continue
 			}
 
@@ -1078,7 +1080,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 			// OmitEmpty skips the field if the marshaled JSON value is empty,
 			// which we can know up front if there are no custom marshalers,
 			// otherwise we must marshal the value and unwrite it if empty.
-			if f.omitempty && !mo.Flags.Get(jsonflags.OmitEmptyWithLegacyDefinition) &&
+			if f.omitempty && !mo.Flags.Get(jsonflags.OmitEmptyWithLegacySemantics) &&
 				!nonDefault && f.isEmpty != nil && f.isEmpty(v) {
 				continue // fast path for omitempty
 			}
@@ -1143,7 +1145,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 			}
 
 			// Try unwriting the member if empty (slow path for omitempty).
-			if f.omitempty && !mo.Flags.Get(jsonflags.OmitEmptyWithLegacyDefinition) {
+			if f.omitempty && !mo.Flags.Get(jsonflags.OmitEmptyWithLegacySemantics) {
 				var prevName *string
 				if prevIdx >= 0 {
 					prevName = &fields.flattened[prevIdx].name

--- a/arshal_time.go
+++ b/arshal_time.go
@@ -48,7 +48,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				if !m.initFormat(mo.Format) {
 					return newInvalidFormatError(enc, t, mo)
 				}
-			} else if mo.Flags.Get(jsonflags.FormatTimeWithLegacySemantics) {
+			} else if mo.Flags.Get(jsonflags.FormatDurationAsNano) {
 				return marshalNano(enc, va, mo)
 			} else {
 				// TODO(https://go.dev/issue/71631): Decide on default duration representation.
@@ -74,7 +74,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				if !u.initFormat(uo.Format) {
 					return newInvalidFormatError(dec, t, uo)
 				}
-			} else if uo.Flags.Get(jsonflags.FormatTimeWithLegacySemantics) {
+			} else if uo.Flags.Get(jsonflags.FormatDurationAsNano) {
 				return unmarshalNano(dec, va, uo)
 			} else {
 				// TODO(https://go.dev/issue/71631): Decide on default duration representation.
@@ -148,7 +148,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				if !u.initFormat(uo.Format) {
 					return newInvalidFormatError(dec, t, uo)
 				}
-			} else if uo.Flags.Get(jsonflags.FormatTimeWithLegacySemantics) {
+			} else if uo.Flags.Get(jsonflags.ParseTimeWithLooseRFC3339) {
 				u.looseRFC3339 = true
 			}
 

--- a/doc.go
+++ b/doc.go
@@ -159,6 +159,100 @@
 // Marshaling or unmarshaling a non-empty struct
 // without any JSON representable fields results in a [SemanticError].
 // Unexported fields must not have any `json` tags except for `json:"-"`.
+//
+// # Security Considerations
+//
+// JSON is frequently used as a data interchange format to communicate
+// between different systems, possibly implemented in different languages.
+// For interoperability and security reasons, it is important that
+// all implementations agree upon the semantic meaning of the data.
+//
+// [For example, suppose we have two micro-services.]
+// The first service is responsible for authenticating a JSON request,
+// while the second service is responsible for executing the request
+// (having assumed that the prior service authenticated the request).
+// If an attacker were able to maliciously craft a JSON request such that
+// both services believe that the same request is from different users,
+// it could bypass the authenticator with valid credentials for one user,
+// but maliciously perform an action on behalf of a different user.
+//
+// According to RFC 8259, there unfortunately exist many JSON texts
+// that are syntactically valid but semantically ambiguous.
+// For example, the standard does not define how to interpret duplicate
+// names within an object.
+//
+// The v1 [encoding/json] and [encoding/json/v2] packages
+// interpret some inputs in different ways. In particular:
+//
+//   - The standard specifies that JSON must be encoded using UTF-8.
+//     By default, v1 replaces invalid bytes of UTF-8 in JSON strings
+//     with the Unicode replacement character,
+//     while v2 rejects inputs with invalid UTF-8.
+//     To change the default, specify the [jsontext.AllowInvalidUTF8] option.
+//     The replacement of invalid UTF-8 is a form of data corruption
+//     that alters the precise meaning of strings.
+//
+//   - The standard does not specify a particular behavior when
+//     duplicate names are encountered within a JSON object,
+//     which means that different implementations may behave differently.
+//     By default, v1 allows for the presence of duplicate names,
+//     while v2 rejects duplicate names.
+//     To change the default, specify the [jsontext.AllowDuplicateNames] option.
+//     If allowed, object members are processed in the order they are observed,
+//     meaning that later values will replace or be merged into prior values,
+//     depending on the Go value type.
+//
+//   - The standard defines a JSON object as an unordered collection of name/value pairs.
+//     While ordering can be observed through the underlying [jsontext] API,
+//     both v1 and v2 generally avoid exposing the ordering.
+//     No application should semantically depend on the order of object members.
+//     Allowing duplicate names is a vector through which ordering of members
+//     can accidentally be observed and depended upon.
+//
+//   - The standard suggests that JSON object names are typically compared
+//     based on equality of the sequence of Unicode code points,
+//     which implies that comparing names is often case-sensitive.
+//     When unmarshaling a JSON object into a Go struct,
+//     by default, v1 uses a (loose) case-insensitive match on the name,
+//     while v2 uses a (strict) case-sensitive match on the name.
+//     To change the default, specify the [MatchCaseInsensitiveNames] option.
+//     The use of case-insensitive matching provides another vector through
+//     which duplicate names can occur. Allowing case-insensitive matching
+//     means that v1 or v2 might interpret JSON objects differently from most
+//     other JSON implementations (which typically use a case-sensitive match).
+//
+//   - The standard does not specify a particular behavior when
+//     an unknown name in a JSON object is encountered.
+//     When unmarshaling a JSON object into a Go struct, by default
+//     both v1 and v2 ignore unknown names and their corresponding values.
+//     To change the default, specify the [RejectUnknownMembers] option.
+//
+//   - The standard suggests that implementations may use a float64
+//     to represent a JSON number. Consequently, large JSON integers
+//     may lose precision when stored as a floating-point type.
+//     Both v1 and v2 correctly preserve precision when marshaling and
+//     unmarshaling a concrete integer type. However, even if v1 and v2
+//     preserve precision for concrete types, other JSON implementations
+//     may not be able to preserve precision for outputs produced by v1 or v2.
+//     The `string` tag option can be used to specify that an integer type
+//     is to be quoted within a JSON string to avoid loss of precision.
+//     Furthermore, v1 and v2 may still lose precision when unmarshaling
+//     into an any interface value, where unmarshal uses a float64
+//     by default to represent a JSON number.
+//     To change the default, specify the [WithUnmarshalers] option
+//     with a custom unmarshaler that pre-populates the interface value
+//     with a concrete Go type that can preserve precision.
+//
+// RFC 8785 specifies a canonical form for any JSON text,
+// which explicitly defines specific behaviors that RFC 8259 leaves undefined.
+// In theory, if a text can successfully [jsontext.Value.Canonicalize]
+// without changing the semantic meaning of the data, then it provides a
+// greater degree of confidence that the data is more secure and interoperable.
+//
+// The v2 API generally chooses more secure defaults than v1,
+// but care should still be taken with large integers or unknown members.
+//
+// [For example, suppose we have two micro-services.]: https://www.youtube.com/watch?v=avilmOcHKHE&t=1057s
 package json
 
 // requireKeyedLiterals can be embedded in a struct to require keyed literals.

--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -50,18 +50,20 @@ const (
 		AllowInvalidUTF8 |
 		EscapeForHTML |
 		EscapeForJS |
-		EscapeInvalidUTF8 |
 		PreserveRawStrings |
 		Deterministic |
 		FormatNilMapAsNull |
 		FormatNilSliceAsNull |
 		MatchCaseInsensitiveNames |
 		CallMethodsWithLegacySemantics |
+		FormatByteArrayAsArray |
 		FormatBytesWithLegacySemantics |
-		FormatTimeWithLegacySemantics |
+		FormatDurationAsNano |
 		MatchCaseSensitiveDelimiter |
 		MergeWithLegacySemantics |
-		OmitEmptyWithLegacyDefinition |
+		OmitEmptyWithLegacySemantics |
+		ParseBytesWithLooseRFC4648 |
+		ParseTimeWithLooseRFC3339 |
 		ReportErrorsWithLegacySemantics |
 		StringifyWithLegacySemantics |
 		UnmarshalArrayFromAnyLength
@@ -75,7 +77,7 @@ const (
 	WhitespaceFlags = AnyWhitespace | Indent | IndentPrefix
 
 	// AnyEscape is the set of flags related to escaping in a JSON string.
-	AnyEscape = EscapeForHTML | EscapeForJS | EscapeInvalidUTF8
+	AnyEscape = EscapeForHTML | EscapeForJS
 
 	// CanonicalizeNumbers is the set of flags related to raw number canonicalization.
 	CanonicalizeNumbers = CanonicalizeRawInts | CanonicalizeRawFloats
@@ -95,7 +97,6 @@ const (
 	ReorderRawObjects     // encode only
 	EscapeForHTML         // encode only
 	EscapeForJS           // encode only
-	EscapeInvalidUTF8     // encode only; only exposed in v1
 	Multiline             // encode only
 	SpaceAfterColon       // encode only
 	SpaceAfterComma       // encode only
@@ -130,11 +131,14 @@ const (
 	_ Bools = (maxArshalV2Flag >> 1) << iota
 
 	CallMethodsWithLegacySemantics  // marshal or unmarshal
+	FormatByteArrayAsArray          // marshal or unmarshal
 	FormatBytesWithLegacySemantics  // marshal or unmarshal
-	FormatTimeWithLegacySemantics   // marshal or unmarshal
+	FormatDurationAsNano            // marshal or unmarshal
 	MatchCaseSensitiveDelimiter     // marshal or unmarshal
 	MergeWithLegacySemantics        // unmarshal
-	OmitEmptyWithLegacyDefinition   // marshal
+	OmitEmptyWithLegacySemantics    // marshal
+	ParseBytesWithLooseRFC4648      // unmarshal
+	ParseTimeWithLooseRFC3339       // unmarshal
 	ReportErrorsWithLegacySemantics // marshal or unmarshal
 	StringifyWithLegacySemantics    // marshal or unmarshal
 	StringifyBoolsAndStrings        // marshal or unmarshal; for internal use by jsonv2.makeStructArshaler
@@ -143,6 +147,12 @@ const (
 
 	maxArshalV1Flag
 )
+
+// bitsUsed is the number of bits used in the 64-bit boolean flags
+const bitsUsed = 42
+
+// Static compile check that bitsUsed and maxArshalV1Flag are in sync.
+const _ = uint64((1<<bitsUsed)-maxArshalV1Flag) + uint64(maxArshalV1Flag-(1<<bitsUsed))
 
 // Flags is a set of boolean flags.
 // If the presence bit is zero, then the value bit must also be zero.

--- a/internal/jsonwire/encode.go
+++ b/internal/jsonwire/encode.go
@@ -90,11 +90,7 @@ func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes, flags *jsonflag
 			case isInvalidUTF8(r, rn):
 				hasInvalidUTF8 = true
 				dst = append(dst, src[i:n-rn]...)
-				if flags.Get(jsonflags.EscapeInvalidUTF8) {
-					dst = append(dst, `\ufffd`...)
-				} else {
-					dst = append(dst, "\ufffd"...)
-				}
+				dst = append(dst, "\ufffd"...)
 				i = n
 			case (r == '\u2028' || r == '\u2029') && flags.Get(jsonflags.EscapeForJS):
 				dst = append(dst, src[i:n-rn]...)

--- a/jsontext/doc.go
+++ b/jsontext/doc.go
@@ -96,6 +96,10 @@
 // RFC 7493 is a stricter subset of RFC 8259 and fully compliant with it.
 // In particular, it makes specific choices about behavior that RFC 8259
 // leaves as undefined in order to ensure greater interoperability.
+//
+// # Security Considerations
+//
+// See the "Security Considerations" section in [encoding/json/v2].
 package jsontext
 
 // requireKeyedLiterals can be embedded in a struct to require keyed literals.

--- a/jsontext/options.go
+++ b/jsontext/options.go
@@ -269,6 +269,7 @@ func WithIndentPrefix(prefix string) Options {
 
 /*
 // TODO(https://go.dev/issue/56733): Implement WithByteLimit and WithDepthLimit.
+// Remember to also update the "Security Considerations" section.
 
 // WithByteLimit sets a limit on the number of bytes of input or output bytes
 // that may be consumed or produced for each top-level JSON value.

--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io"
 	"maps"
 	"math"
 	"math/big"
@@ -471,11 +472,13 @@ var unmarshalTests = []struct {
 	{CaseName: Name(""), in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
 
 	// syntax errors
+	{CaseName: Name(""), in: ``, ptr: new(any), err: &SyntaxError{errUnexpectedEnd.Error(), 0}},
+	{CaseName: Name(""), in: " \n\r\t", ptr: new(any), err: &SyntaxError{errUnexpectedEnd.Error(), len64(" \n\r\t")}},
+	{CaseName: Name(""), in: `[2, 3`, ptr: new(any), err: &SyntaxError{errUnexpectedEnd.Error(), len64(`[2, 3`)}},
 	{CaseName: Name(""), in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", len64(`{"X": "foo", "Y"`)}},
 	{CaseName: Name(""), in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", len64(`[1, 2, 3`)}},
 	{CaseName: Name(""), in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", len64(`{"X":12`)}, useNumber: true},
-	{CaseName: Name(""), in: `[2, 3`, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: len64(`[2, 3`)}},
-	{CaseName: Name(""), in: `{"F3": -}`, ptr: new(V), err: &SyntaxError{msg: "invalid character '}' in numeric literal", Offset: len64(`{"F3": -`)}},
+	{CaseName: Name(""), in: `{"F3": -}`, ptr: new(V), err: &SyntaxError{"invalid character '}' in numeric literal", len64(`{"F3": -`)}},
 
 	// raw value errors
 	{CaseName: Name(""), in: "\x01 42", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", len64(``)}},
@@ -1244,12 +1247,12 @@ func TestMarshalInvalidUTF8(t *testing.T) {
 		in   string
 		want string
 	}{
-		{Name(""), "hello\xffworld", `"hello\ufffdworld"`},
+		{Name(""), "hello\xffworld", "\"hello\ufffdworld\""},
 		{Name(""), "", `""`},
-		{Name(""), "\xff", `"\ufffd"`},
-		{Name(""), "\xff\xff", `"\ufffd\ufffd"`},
-		{Name(""), "a\xffb", `"a\ufffdb"`},
-		{Name(""), "\xe6\x97\xa5\xe6\x9c\xac\xff\xaa\x9e", `"日本\ufffd\ufffd\ufffd"`},
+		{Name(""), "\xff", "\"\ufffd\""},
+		{Name(""), "\xff\xff", "\"\ufffd\ufffd\""},
+		{Name(""), "a\xffb", "\"a\ufffdb\""},
+		{Name(""), "\xe6\x97\xa5\xe6\x9c\xac\xff\xaa\x9e", "\"日本\ufffd\ufffd\ufffd\""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -1379,6 +1382,14 @@ func TestUnmarshal(t *testing.T) {
 			}
 			if tt.disallowUnknownFields {
 				dec.DisallowUnknownFields()
+			}
+			if tt.err != nil && strings.Contains(tt.err.Error(), errUnexpectedEnd.Error()) {
+				// In streaming mode, we expect EOF or ErrUnexpectedEOF instead.
+				if strings.TrimSpace(tt.in) == "" {
+					tt.err = io.EOF
+				} else {
+					tt.err = io.ErrUnexpectedEOF
+				}
 			}
 			if err := dec.Decode(v.Interface()); !equalError(err, tt.err) {
 				t.Fatalf("%s: Decode error:\n\tgot:  %v\n\twant: %v\n\n\tgot:  %#v\n\twant: %#v", tt.Where, err, tt.err, err, tt.err)

--- a/v1/diff_test.go
+++ b/v1/diff_test.go
@@ -784,8 +784,8 @@ func TestInvalidUTF8(t *testing.T) {
 			switch {
 			case json.Version == "v1" && err != nil:
 				t.Fatalf("json.Marshal error: %v", err)
-			case json.Version == "v1" && string(got) != `"\ufffd"`:
-				t.Fatalf(`json.Marshal = %s, want "\ufffd"`, got)
+			case json.Version == "v1" && string(got) != "\"\ufffd\"":
+				t.Fatalf(`json.Marshal = %s, want %q`, got, "\ufffd")
 			case json.Version == "v2" && err == nil:
 				t.Fatal("json.Marshal error is nil, want non-nil")
 			}

--- a/v1/encode.go
+++ b/v1/encode.go
@@ -8,6 +8,14 @@
 //
 // See "JSON and Go" for an introduction to this package:
 // https://golang.org/doc/articles/json_and_go.html
+//
+// # Security Considerations
+//
+// See the "Security Considerations" section in [encoding/json/v2].
+//
+// For historical reasons, the default behavior of v1 [encoding/json]
+// unfortunately operates with less secure defaults.
+// New usages of JSON in Go are encouraged to use [encoding/json/v2] instead.
 package json
 
 import (

--- a/v1/options.go
+++ b/v1/options.go
@@ -34,7 +34,7 @@
 //     any empty array, slice, map, or string. In contrast, v2 redefines
 //     `omitempty` to omit a field if it encodes as an "empty" JSON value,
 //     which is defined as a JSON null, or an empty JSON string, object, or array.
-//     The [OmitEmptyWithLegacyDefinition] option controls this behavior difference.
+//     The [OmitEmptyWithLegacySemantics] option controls this behavior difference.
 //     Note that `omitempty` behaves identically in both v1 and v2 for a
 //     Go array, slice, map, or string (assuming no user-defined MarshalJSON method
 //     overrides the default representation). Existing usages of `omitempty` on a
@@ -64,7 +64,7 @@
 //
 //   - In v1, a Go byte array is represented as a JSON array of JSON numbers.
 //     In contrast, in v2 a Go byte array is represented as a Base64-encoded JSON string.
-//     The [FormatBytesWithLegacySemantics] option controls this behavior difference.
+//     The [FormatByteArrayAsArray] option controls this behavior difference.
 //     To explicitly specify a Go struct field to use a particular representation,
 //     either the `format:array` or `format:base64` field option can be specified.
 //     Field-specified options take precedence over caller-specified options.
@@ -116,9 +116,8 @@
 //
 //   - In v1, a [time.Duration] is represented as a JSON number containing
 //     the decimal number of nanoseconds. In contrast, in v2 a [time.Duration]
-//     is represented as a JSON string containing the formatted duration
-//     (e.g., "1h2m3.456s") according to [time.Duration.String].
-//     The [FormatTimeWithLegacySemantics] option controls this behavior difference.
+//     has no default representation and results in a runtime error.
+//     The [FormatDurationAsNano] option controls this behavior difference.
 //     To explicitly specify a Go struct field to use a particular representation,
 //     either the `format:nano` or `format:units` field option can be specified.
 //     Field-specified options take precedence over caller-specified options.
@@ -170,6 +169,9 @@
 // but the v1 package will forever remain supported.
 package json
 
+// TODO(https://go.dev/issue/71631): Update the "Migrating to v2" documentation
+// with default v2 behavior for [time.Duration].
+
 import (
 	"encoding"
 
@@ -202,12 +204,14 @@ type Options = jsonopts.Options
 // It is equivalent to the following boolean options being set to true:
 //
 //   - [CallMethodsWithLegacySemantics]
-//   - [EscapeInvalidUTF8]
+//   - [FormatByteArrayAsArray]
 //   - [FormatBytesWithLegacySemantics]
-//   - [FormatTimeWithLegacySemantics]
+//   - [FormatDurationAsNano]
 //   - [MatchCaseSensitiveDelimiter]
 //   - [MergeWithLegacySemantics]
-//   - [OmitEmptyWithLegacyDefinition]
+//   - [OmitEmptyWithLegacySemantics]
+//   - [ParseBytesWithLooseRFC4648]
+//   - [ParseTimeWithLooseRFC3339]
 //   - [ReportErrorsWithLegacySemantics]
 //   - [StringifyWithLegacySemantics]
 //   - [UnmarshalArrayFromAnyLength]
@@ -277,29 +281,24 @@ func CallMethodsWithLegacySemantics(v bool) Options {
 	}
 }
 
-// EscapeInvalidUTF8 specifies that when encoding a [jsontext.String]
-// with bytes of invalid UTF-8, such bytes are escaped as
-// a hexadecimal Unicode codepoint (i.e., \ufffd).
-// In contrast, the v2 default is to use the minimal representation,
-// which is to encode invalid UTF-8 as the Unicode replacement rune itself
-// (without any form of escaping).
+// FormatByteArrayAsArray specifies that a Go [N]byte is
+// formatted as as a normal Go array in contrast to the v2 default of
+// formatting [N]byte as using binary data encoding (RFC 4648).
+// If a struct field has a `format` tag option,
+// then the specified formatting takes precedence.
 //
-// This only affects encoding and is ignored when decoding.
+// This affects either marshaling or unmarshaling.
 // The v1 default is true.
-func EscapeInvalidUTF8(v bool) Options {
+func FormatByteArrayAsArray(v bool) Options {
 	if v {
-		return jsonflags.EscapeInvalidUTF8 | 1
+		return jsonflags.FormatByteArrayAsArray | 1
 	} else {
-		return jsonflags.EscapeInvalidUTF8 | 0
+		return jsonflags.FormatByteArrayAsArray | 0
 	}
 }
 
 // FormatBytesWithLegacySemantics specifies that handling of
 // []~byte and [N]~byte types follow legacy semantics:
-//
-//   - A Go [N]~byte is always treated as as a normal Go array
-//     in contrast to the v2 default of treating [N]byte as
-//     using some form of binary data encoding (RFC 4648).
 //
 //   - A Go []~byte is to be treated as using some form of
 //     binary data encoding (RFC 4648) in contrast to the v2 default
@@ -315,12 +314,6 @@ func EscapeInvalidUTF8(v bool) Options {
 //     In contrast, the v2 default is to report an error unmarshaling
 //     a JSON array when expecting some form of binary data encoding.
 //
-//   - When unmarshaling, '\r' and '\n' characters are ignored
-//     within the encoded "base32" and "base64" data.
-//     In contrast, the v2 default is to report an error in order to be
-//     strictly compliant with RFC 4648, section 3.3,
-//     which specifies that non-alphabet characters must be rejected.
-//
 // This affects either marshaling or unmarshaling.
 // The v1 default is true.
 func FormatBytesWithLegacySemantics(v bool) Options {
@@ -331,29 +324,20 @@ func FormatBytesWithLegacySemantics(v bool) Options {
 	}
 }
 
-// FormatTimeWithLegacySemantics specifies that [time] types are formatted
-// with legacy semantics:
-//
-//   - When marshaling or unmarshaling, a [time.Duration] is formatted as
-//     a JSON number representing the number of nanoseconds.
-//     In contrast, the default v2 behavior uses a JSON string
-//     with the duration formatted with [time.Duration.String].
-//     If a duration field has a `format` tag option,
-//     then the specified formatting takes precedence.
-//
-//   - When unmarshaling, a [time.Time] follows loose adherence to RFC 3339.
-//     In particular, it permits historically incorrect representations,
-//     allowing for deviations in hour format, sub-second separator,
-//     and timezone representation. In contrast, the default v2 behavior
-//     is to strictly comply with the grammar specified in RFC 3339.
+// FormatDurationAsNano specifies that a [time.Duration] is
+// formatted as a JSON number representing the number of nanoseconds
+// in contrast to the v2 default of reporting an error.
+// If a duration field has a `format` tag option,
+// then the specified formatting takes precedence.
 //
 // This affects either marshaling or unmarshaling.
 // The v1 default is true.
-func FormatTimeWithLegacySemantics(v bool) Options {
+func FormatDurationAsNano(v bool) Options {
+	// TODO(https://go.dev/issue/71631): Update documentation with v2 behavior.
 	if v {
-		return jsonflags.FormatTimeWithLegacySemantics | 1
+		return jsonflags.FormatDurationAsNano | 1
 	} else {
-		return jsonflags.FormatTimeWithLegacySemantics | 0
+		return jsonflags.FormatDurationAsNano | 0
 	}
 }
 
@@ -402,7 +386,7 @@ func MergeWithLegacySemantics(v bool) Options {
 	}
 }
 
-// OmitEmptyWithLegacyDefinition specifies that the `omitempty` tag option
+// OmitEmptyWithLegacySemantics specifies that the `omitempty` tag option
 // follows a definition of empty where a field is omitted if the Go value is
 // false, 0, a nil pointer, a nil interface value,
 // or any empty array, slice, map, or string.
@@ -416,11 +400,45 @@ func MergeWithLegacySemantics(v bool) Options {
 //
 // This only affects marshaling and is ignored when unmarshaling.
 // The v1 default is true.
-func OmitEmptyWithLegacyDefinition(v bool) Options {
+func OmitEmptyWithLegacySemantics(v bool) Options {
 	if v {
-		return jsonflags.OmitEmptyWithLegacyDefinition | 1
+		return jsonflags.OmitEmptyWithLegacySemantics | 1
 	} else {
-		return jsonflags.OmitEmptyWithLegacyDefinition | 0
+		return jsonflags.OmitEmptyWithLegacySemantics | 0
+	}
+}
+
+// ParseBytesWithLooseRFC4648 specifies that when parsing
+// binary data encoded as "base32" or "base64",
+// to ignore the presence of '\r' and '\n' characters.
+// In contrast, the v2 default is to report an error in order to be
+// strictly compliant with RFC 4648, section 3.3,
+// which specifies that non-alphabet characters must be rejected.
+//
+// This only affects unmarshaling and is ignored when marshaling.
+// The v1 default is true.
+func ParseBytesWithLooseRFC4648(v bool) Options {
+	if v {
+		return jsonflags.ParseBytesWithLooseRFC4648 | 1
+	} else {
+		return jsonflags.ParseBytesWithLooseRFC4648 | 0
+	}
+}
+
+// ParseTimeWithLooseRFC3339 specifies that a [time.Time]
+// parses according to loose adherence to RFC 3339.
+// In particular, it permits historically incorrect representations,
+// allowing for deviations in hour format, sub-second separator,
+// and timezone representation. In contrast, the default v2 behavior
+// is to strictly comply with the grammar specified in RFC 3339.
+//
+// This only affects unmarshaling and is ignored when marshaling.
+// The v1 default is true.
+func ParseTimeWithLooseRFC3339(v bool) Options {
+	if v {
+		return jsonflags.ParseTimeWithLooseRFC3339 | 1
+	} else {
+		return jsonflags.ParseTimeWithLooseRFC3339 | 0
 	}
 }
 

--- a/v1/scanner.go
+++ b/v1/scanner.go
@@ -28,6 +28,10 @@ func checkValid(data []byte) error {
 	xd := export.Decoder(d)
 	xd.Struct.Flags.Set(jsonflags.AllowDuplicateNames | jsonflags.AllowInvalidUTF8 | 1)
 	if _, err := d.ReadValue(); err != nil {
+		if err == io.EOF {
+			offset := d.InputOffset() + int64(len(d.UnreadBuffer()))
+			err = &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
+		}
 		return transformSyntacticError(err)
 	}
 	if err := xd.CheckEOF(); err != nil {

--- a/v1/stream.go
+++ b/v1/stream.go
@@ -66,7 +66,7 @@ func (dec *Decoder) Decode(v any) error {
 	b, err := dec.dec.ReadValue()
 	if err != nil {
 		dec.err = transformSyntacticError(err)
-		if dec.err == errUnexpectedEnd {
+		if dec.err.Error() == errUnexpectedEnd.Error() {
 			// NOTE: Decode has always been inconsistent with Unmarshal
 			// with regard to the exact error value for truncated input.
 			dec.err = io.ErrUnexpectedEOF


### PR DESCRIPTION
WARNING: This commit contains breaking changes.

The FormatBytesWithLegacySemantics option has been split apart as:
* FormatBytesWithLegacySemantics
* FormatByteArrayAsArray
* ParseBytesWithLooseRFC4648

The FormatTimeWithLegacySemantics option has been split apart as:
* FormatDurationAsNano
* ParseTimeWithLooseRFC3339

The EscapeInvalidUTF8 option has been removed.

This pulls in the following changes:
* (https://go.dev/cl/685395) encoding/json: decompose legacy options
* (https://go.dev/cl/685195) encoding/json/v2: add security section to doc
* (https://go.dev/cl/687116) encoding/json: remove legacy option to EscapeInvalidUTF8
* (https://go.dev/cl/687115) encoding/json/v2: report wrapped io.ErrUnexpectedEOF