### PR TITLE
Update to c76c3abc5426ab3d183514c834bcd7d6a653ae89

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -407,7 +407,7 @@ func Unmarshal(in []byte, out any, opts ...Options) (err error) {
 	dec := export.GetBufferedDecoder(in, opts...)
 	defer export.PutBufferedDecoder(dec)
 	xd := export.Decoder(dec)
-	err = unmarshalFull(dec, out, &xd.Struct)
+	err = unmarshalDecode(dec, out, &xd.Struct, true)
 	if err != nil && xd.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
 		return internal.TransformUnmarshalError(out, err)
 	}
@@ -424,23 +424,11 @@ func UnmarshalRead(in io.Reader, out any, opts ...Options) (err error) {
 	dec := export.GetStreamingDecoder(in, opts...)
 	defer export.PutStreamingDecoder(dec)
 	xd := export.Decoder(dec)
-	err = unmarshalFull(dec, out, &xd.Struct)
+	err = unmarshalDecode(dec, out, &xd.Struct, true)
 	if err != nil && xd.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
 		return internal.TransformUnmarshalError(out, err)
 	}
 	return err
-}
-
-func unmarshalFull(in *jsontext.Decoder, out any, uo *jsonopts.Struct) error {
-	switch err := unmarshalDecode(in, out, uo); err {
-	case nil:
-		return export.Decoder(in).CheckEOF()
-	case io.EOF:
-		offset := in.InputOffset() + int64(len(in.UnreadBuffer()))
-		return &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
-	default:
-		return err
-	}
 }
 
 // UnmarshalDecode deserializes a Go value from a [jsontext.Decoder] according to
@@ -461,14 +449,14 @@ func UnmarshalDecode(in *jsontext.Decoder, out any, opts ...Options) (err error)
 		defer func() { xd.Struct = optsOriginal }()
 		xd.Struct.JoinWithoutCoderOptions(opts...)
 	}
-	err = unmarshalDecode(in, out, &xd.Struct)
+	err = unmarshalDecode(in, out, &xd.Struct, false)
 	if err != nil && xd.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
 		return internal.TransformUnmarshalError(out, err)
 	}
 	return err
 }
 
-func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct) (err error) {
+func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct, last bool) (err error) {
 	v := reflect.ValueOf(out)
 	if v.Kind() != reflect.Pointer || v.IsNil() {
 		return &SemanticError{action: "unmarshal", GoType: reflect.TypeOf(out), Err: internal.ErrNonNilReference}
@@ -479,7 +467,11 @@ func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct) (err er
 	// In legacy semantics, the entirety of the next JSON value
 	// was validated before attempting to unmarshal it.
 	if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
-		if err := export.Decoder(in).CheckNextValue(); err != nil {
+		if err := export.Decoder(in).CheckNextValue(last); err != nil {
+			if err == io.EOF {
+				offset := in.InputOffset() + int64(len(in.UnreadBuffer()))
+				return &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
+			}
 			return err
 		}
 	}
@@ -493,7 +485,14 @@ func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct) (err er
 		if !uo.Flags.Get(jsonflags.AllowDuplicateNames) {
 			export.Decoder(in).Tokens.InvalidateDisabledNamespaces()
 		}
+		if err == io.EOF {
+			offset := in.InputOffset() + int64(len(in.UnreadBuffer()))
+			return &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
+		}
 		return err
+	}
+	if last {
+		return export.Decoder(in).CheckEOF()
 	}
 	return nil
 }

--- a/arshal_default.go
+++ b/arshal_default.go
@@ -1688,8 +1688,6 @@ func makePointerArshaler(t reflect.Type) *arshaler {
 	return &fncs
 }
 
-var errNilInterface = errors.New("cannot derive concrete type for nil interface with finite type set")
-
 func makeInterfaceArshaler(t reflect.Type) *arshaler {
 	// NOTE: Values retrieved from an interface are not addressable,
 	// so we shallow copy the values to make them addressable and
@@ -1795,7 +1793,7 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 
 			k := dec.PeekKind()
 			if !isAnyType(t) {
-				return newUnmarshalErrorBeforeWithSkipping(dec, uo, t, errNilInterface)
+				return newUnmarshalErrorBeforeWithSkipping(dec, uo, t, internal.ErrNilInterface)
 			}
 			switch k {
 			case 'f', 't':

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -7494,7 +7494,7 @@ func TestUnmarshal(t *testing.T) {
 		inBuf:   `"hello"`,
 		inVal:   new(io.Reader),
 		want:    new(io.Reader),
-		wantErr: EU(errNilInterface).withType(0, T[io.Reader]()),
+		wantErr: EU(internal.ErrNilInterface).withType(0, T[io.Reader]()),
 	}, {
 		name:  jsontest.Name("Interfaces/Empty/False"),
 		inBuf: `false`,
@@ -8342,7 +8342,7 @@ func TestUnmarshal(t *testing.T) {
 		inBuf:   `{"X":"hello"}`,
 		inVal:   addr(struct{ X fmt.Stringer }{nil}),
 		want:    addr(struct{ X fmt.Stringer }{nil}),
-		wantErr: EU(errNilInterface).withPos(`{"X":`, "/X").withType(0, T[fmt.Stringer]()),
+		wantErr: EU(internal.ErrNilInterface).withPos(`{"X":`, "/X").withType(0, T[fmt.Stringer]()),
 	}, {
 		name: jsontest.Name("Functions/Interface/NetIP"),
 		opts: []Options{

--- a/errors.go
+++ b/errors.go
@@ -118,10 +118,17 @@ func newMarshalErrorBefore(e *jsontext.Encoder, t reflect.Type, err error) error
 // is positioned right before the next token or value, which causes an error.
 // It does not record the next JSON kind as this error is used to indicate
 // the receiving Go value is invalid to unmarshal into (and not a JSON error).
+// However, if [jsonflags.ReportErrorsWithLegacySemantics] is specified,
+// then it does record the next JSON kind for historical reporting reasons.
 func newUnmarshalErrorBefore(d *jsontext.Decoder, t reflect.Type, err error) error {
+	var k jsontext.Kind
+	if export.Decoder(d).Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
+		k = d.PeekKind()
+	}
 	return &SemanticError{action: "unmarshal", GoType: t, Err: err,
 		ByteOffset:  d.InputOffset() + int64(export.Decoder(d).CountNextDelimWhitespace()),
-		JSONPointer: jsontext.Pointer(export.Decoder(d).AppendStackPointer(nil, +1))}
+		JSONPointer: jsontext.Pointer(export.Decoder(d).AppendStackPointer(nil, +1)),
+		JSONKind:    k}
 }
 
 // newUnmarshalErrorBeforeWithSkipping is like [newUnmarshalErrorBefore],

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -19,6 +19,7 @@ var AllowInternalUse NotForPublicUse
 var (
 	ErrCycle           = errors.New("encountered a cycle")
 	ErrNonNilReference = errors.New("value must be passed as a non-nil pointer reference")
+	ErrNilInterface    = errors.New("cannot derive concrete type for nil interface with finite type set")
 )
 
 var (

--- a/jsontext/decode.go
+++ b/jsontext/decode.go
@@ -136,7 +136,12 @@ func (d *Decoder) Reset(r io.Reader, opts ...Options) {
 	case d.s.Flags.Get(jsonflags.WithinArshalCall):
 		panic("jsontext: cannot reset Decoder passed to json.UnmarshalerFrom")
 	}
-	d.s.reset(nil, r, opts...)
+	// Reuse the buffer if it does not alias a previous [bytes.Buffer].
+	b := d.s.buf[:0]
+	if _, ok := d.s.rd.(*bytes.Buffer); ok {
+		b = nil
+	}
+	d.s.reset(b, r, opts...)
 }
 
 func (d *decoderState) reset(b []byte, r io.Reader, opts ...Options) {
@@ -767,7 +772,8 @@ func (d *decoderState) ReadValue(flags *jsonwire.ValueFlags) (Value, error) {
 
 // CheckNextValue checks whether the next value is syntactically valid,
 // but does not advance the read offset.
-func (d *decoderState) CheckNextValue() error {
+// If last, it verifies that the stream cleanly terminates with [io.EOF].
+func (d *decoderState) CheckNextValue(last bool) error {
 	d.PeekKind() // populates d.peekPos and d.peekErr
 	pos, err := d.peekPos, d.peekErr
 	d.peekPos, d.peekErr = 0, nil
@@ -778,13 +784,18 @@ func (d *decoderState) CheckNextValue() error {
 	var flags jsonwire.ValueFlags
 	if pos, err := d.consumeValue(&flags, pos, d.Tokens.Depth()); err != nil {
 		return wrapSyntacticError(d, err, pos, +1)
+	} else if last {
+		return d.checkEOF(pos)
 	}
 	return nil
 }
 
 // CheckEOF verifies that the input has no more data.
 func (d *decoderState) CheckEOF() error {
-	switch pos, err := d.consumeWhitespace(d.prevEnd); err {
+	return d.checkEOF(d.prevEnd)
+}
+func (d *decoderState) checkEOF(pos int) error {
+	switch pos, err := d.consumeWhitespace(pos); err {
 	case nil:
 		err := jsonwire.NewInvalidCharacterError(d.buf[pos:], "after top-level value")
 		return wrapSyntacticError(d, err, pos, 0)

--- a/jsontext/decode_test.go
+++ b/jsontext/decode_test.go
@@ -1263,3 +1263,86 @@ func TestPeekableDecoder(t *testing.T) {
 		}
 	}
 }
+
+// TestDecoderReset tests that the decoder preserves its internal
+// buffer between Reset calls to avoid frequent allocations when reusing the decoder.
+// It ensures that the buffer capacity is maintained while avoiding aliasing
+// issues with [bytes.Buffer].
+func TestDecoderReset(t *testing.T) {
+	// Create a decoder with a reasonably large JSON input to ensure buffer growth.
+	largeJSON := `{"key1":"value1","key2":"value2","key3":"value3","key4":"value4","key5":"value5"}`
+	dec := NewDecoder(strings.NewReader(largeJSON))
+
+	t.Run("Test capacity preservation", func(t *testing.T) {
+		// Read the first JSON value to grow the internal buffer.
+		val1, err := dec.ReadValue()
+		if err != nil {
+			t.Fatalf("first ReadValue failed: %v", err)
+		}
+		if string(val1) != largeJSON {
+			t.Fatalf("first ReadValue = %q, want %q", val1, largeJSON)
+		}
+
+		// Get the buffer capacity after first use.
+		initialCapacity := cap(dec.s.buf)
+		if initialCapacity == 0 {
+			t.Fatalf("expected non-zero buffer capacity after first use")
+		}
+
+		// Reset with a new reader - this should preserve the buffer capacity.
+		dec.Reset(strings.NewReader(largeJSON))
+
+		// Verify the buffer capacity is preserved (or at least not smaller).
+		preservedCapacity := cap(dec.s.buf)
+		if preservedCapacity < initialCapacity {
+			t.Fatalf("buffer capacity reduced after Reset: got %d, want at least %d", preservedCapacity, initialCapacity)
+		}
+
+		// Read the second JSON value to ensure the decoder still works correctly.
+		val2, err := dec.ReadValue()
+		if err != nil {
+			t.Fatalf("second ReadValue failed: %v", err)
+		}
+		if string(val2) != largeJSON {
+			t.Fatalf("second ReadValue = %q, want %q", val2, largeJSON)
+		}
+	})
+
+	var bbBuf []byte
+	t.Run("Test aliasing with bytes.Buffer", func(t *testing.T) {
+		// Test with bytes.Buffer to verify proper aliasing behavior.
+		bb := bytes.NewBufferString(largeJSON)
+		dec.Reset(bb)
+		bbBuf = bb.Bytes()
+
+		// Read the third JSON value to ensure functionality with bytes.Buffer.
+		val3, err := dec.ReadValue()
+		if err != nil {
+			t.Fatalf("fourth ReadValue failed: %v", err)
+		}
+		if string(val3) != largeJSON {
+			t.Fatalf("fourth ReadValue = %q, want %q", val3, largeJSON)
+		}
+		// The decoder buffer should alias bytes.Buffer's internal buffer.
+		if len(dec.s.buf) == 0 || len(bbBuf) == 0 || &dec.s.buf[0] != &bbBuf[0] {
+			t.Fatalf("decoder buffer does not alias bytes.Buffer")
+		}
+	})
+
+	t.Run("Test aliasing removed after Reset", func(t *testing.T) {
+		// Reset with a new reader and verify the buffer is not aliased.
+		dec.Reset(strings.NewReader(largeJSON))
+		val4, err := dec.ReadValue()
+		if err != nil {
+			t.Fatalf("fifth ReadValue failed: %v", err)
+		}
+		if string(val4) != largeJSON {
+			t.Fatalf("fourth ReadValue = %q, want %q", val4, largeJSON)
+		}
+
+		// The decoder buffer should not alias the bytes.Buffer's internal buffer.
+		if len(dec.s.buf) == 0 || len(bbBuf) == 0 || &dec.s.buf[0] == &bbBuf[0] {
+			t.Fatalf("decoder buffer aliases bytes.Buffer")
+		}
+	})
+}

--- a/jsontext/encode.go
+++ b/jsontext/encode.go
@@ -105,12 +105,17 @@ func (e *Encoder) Reset(w io.Writer, opts ...Options) {
 	case e.s.Flags.Get(jsonflags.WithinArshalCall):
 		panic("jsontext: cannot reset Encoder passed to json.MarshalerTo")
 	}
-	e.s.reset(nil, w, opts...)
+	// Reuse the buffer if it does not alias a previous [bytes.Buffer].
+	b := e.s.Buf[:0]
+	if _, ok := e.s.wr.(*bytes.Buffer); ok {
+		b = nil
+	}
+	e.s.reset(b, w, opts...)
 }
 
 func (e *encoderState) reset(b []byte, w io.Writer, opts ...Options) {
 	e.state.reset()
-	e.encodeBuffer = encodeBuffer{Buf: b, wr: w, bufStats: e.bufStats}
+	e.encodeBuffer = encodeBuffer{Buf: b, wr: w, availBuffer: e.availBuffer, bufStats: e.bufStats}
 	if bb, ok := w.(*bytes.Buffer); ok && bb != nil {
 		e.Buf = bb.AvailableBuffer() // alias the unused buffer of bb
 	}

--- a/jsontext/encode_test.go
+++ b/jsontext/encode_test.go
@@ -733,3 +733,95 @@ func testEncoderErrors(t *testing.T, where jsontest.CasePos, opts []Options, cal
 		t.Fatalf("%s: Encoder.OutputOffset = %v, want %v", where, gotOffset, wantOffset)
 	}
 }
+
+// TestEncoderReset tests that the encoder preserves its internal
+// buffer between Reset calls to avoid frequent allocations when reusing the encoder.
+// It ensures that the buffer capacity is maintained while avoiding aliasing
+// issues with [bytes.Buffer].
+func TestEncoderReset(t *testing.T) {
+	// Create an encoder with a reasonably large JSON input to ensure buffer growth.
+	largeJSON := `{"key1":"value1","key2":"value2","key3":"value3","key4":"value4","key5":"value5"}` + "\n"
+	bb := new(bytes.Buffer)
+	enc := NewEncoder(struct{ io.Writer }{bb}) // mask out underlying [bytes.Buffer]
+
+	t.Run("Test capacity preservation", func(t *testing.T) {
+		// Write the first JSON value to grow the internal buffer.
+		err := enc.WriteValue(append(enc.AvailableBuffer(), largeJSON...))
+		if err != nil {
+			t.Fatalf("first WriteValue failed: %v", err)
+		}
+		if bb.String() != largeJSON {
+			t.Fatalf("first WriteValue = %q, want %q", bb.String(), largeJSON)
+		}
+
+		// Get the buffer capacity after first use.
+		initialCapacity := cap(enc.s.Buf)
+		initialCacheCapacity := cap(enc.s.availBuffer)
+		if initialCapacity == 0 {
+			t.Fatalf("expected non-zero buffer capacity after first use")
+		}
+		if initialCacheCapacity == 0 {
+			t.Fatalf("expected non-zero cache capacity after first use")
+		}
+
+		// Reset with a new writer - this should preserve the buffer capacity.
+		bb.Reset()
+		enc.Reset(struct{ io.Writer }{bb})
+
+		// Verify the buffer capacity is preserved (or at least not smaller).
+		preservedCapacity := cap(enc.s.Buf)
+		if preservedCapacity < initialCapacity {
+			t.Fatalf("buffer capacity reduced after Reset: got %d, want at least %d", preservedCapacity, initialCapacity)
+		}
+		preservedCacheCapacity := cap(enc.s.availBuffer)
+		if preservedCacheCapacity < initialCacheCapacity {
+			t.Fatalf("cache capacity reduced after Reset: got %d, want at least %d", preservedCapacity, initialCapacity)
+		}
+
+		// Write the second JSON value to ensure the encoder still works correctly.
+		err = enc.WriteValue(append(enc.AvailableBuffer(), largeJSON...))
+		if err != nil {
+			t.Fatalf("second WriteValue failed: %v", err)
+		}
+		if bb.String() != largeJSON {
+			t.Fatalf("second WriteValue = %q, want %q", bb.String(), largeJSON)
+		}
+	})
+
+	t.Run("Test aliasing with bytes.Buffer", func(t *testing.T) {
+		// Test with bytes.Buffer to verify proper aliasing behavior.
+		bb.Reset()
+		enc.Reset(bb)
+
+		// Write the third JSON value to ensure functionality with bytes.Buffer.
+		err := enc.WriteValue([]byte(largeJSON))
+		if err != nil {
+			t.Fatalf("fourth WriteValue failed: %v", err)
+		}
+		if bb.String() != largeJSON {
+			t.Fatalf("fourth WriteValue = %q, want %q", bb.String(), largeJSON)
+		}
+		// The encoder buffer should alias bytes.Buffer's internal buffer.
+		if cap(enc.s.Buf) == 0 || cap(bb.AvailableBuffer()) == 0 || &enc.s.Buf[:1][0] != &bb.AvailableBuffer()[:1][0] {
+			t.Fatalf("encoder buffer does not alias bytes.Buffer")
+		}
+	})
+
+	t.Run("Test aliasing removed after Reset", func(t *testing.T) {
+		// Reset with a new reader and verify the buffer is not aliased.
+		bb.Reset()
+		enc.Reset(struct{ io.Writer }{bb})
+		err := enc.WriteValue([]byte(largeJSON))
+		if err != nil {
+			t.Fatalf("fifth WriteValue failed: %v", err)
+		}
+		if bb.String() != largeJSON {
+			t.Fatalf("fourth WriteValue = %q, want %q", bb.String(), largeJSON)
+		}
+
+		// The encoder buffer should not alias the bytes.Buffer's internal buffer.
+		if cap(enc.s.Buf) == 0 || cap(bb.AvailableBuffer()) == 0 || &enc.s.Buf[:1][0] == &bb.AvailableBuffer()[:1][0] {
+			t.Fatalf("encoder buffer aliases bytes.Buffer")
+		}
+	})
+}

--- a/v1/decode.go
+++ b/v1/decode.go
@@ -115,19 +115,11 @@ type UnmarshalTypeError struct {
 }
 
 func (e *UnmarshalTypeError) Error() string {
-	s := "json: cannot unmarshal"
-	if e.Value != "" {
-		s += " JSON " + e.Value
-	}
-	s += " into"
-	var preposition string
-	if e.Field != "" {
-		s += " " + e.Struct + "." + e.Field
-		preposition = " of"
-	}
-	if e.Type != nil {
-		s += preposition
-		s += " Go type " + e.Type.String()
+	var s string
+	if e.Struct != "" || e.Field != "" {
+		s = "json: cannot unmarshal " + e.Value + " into Go struct field " + e.Struct + "." + e.Field + " of type " + e.Type.String()
+	} else {
+		s = "json: cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
 	}
 	if e.Err != nil {
 		s += ": " + e.Err.Error()

--- a/v1/decode_test.go
+++ b/v1/decode_test.go
@@ -418,6 +418,8 @@ type DoublePtr struct {
 	J **int
 }
 
+type NestedUnamed struct{ F struct{ V int } }
+
 var unmarshalTests = []struct {
 	CaseName
 	in                    string
@@ -1217,6 +1219,28 @@ var unmarshalTests = []struct {
 			F string `json:"-,omitempty"`
 		}{"hello"},
 	},
+
+	{
+		CaseName: Name("ErrorForNestedUnamed"),
+		in:       `{"F":{"V":"s"}}`,
+		ptr:      new(NestedUnamed),
+		out:      NestedUnamed{},
+		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[int](), Offset: 10, Struct: "NestedUnamed", Field: "F.V"},
+	},
+	{
+		CaseName: Name("ErrorInterface"),
+		in:       `1`,
+		ptr:      new(error),
+		out:      error(nil),
+		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[error]()},
+	},
+	{
+		CaseName: Name("ErrorChan"),
+		in:       `1`,
+		ptr:      new(chan int),
+		out:      (chan int)(nil),
+		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[chan int]()},
+	},
 }
 
 func TestMarshal(t *testing.T) {
@@ -1550,12 +1574,12 @@ func TestErrorMessageFromMisusedString(t *testing.T) {
 		CaseName
 		in, err string
 	}{
-		{Name(""), `{"result":"x"}`, `json: cannot unmarshal JSON string into WrongString.result of Go type string: invalid character 'x' looking for beginning of object key string`},
-		{Name(""), `{"result":"foo"}`, `json: cannot unmarshal JSON string into WrongString.result of Go type string: invalid character 'f' looking for beginning of object key string`},
-		{Name(""), `{"result":"123"}`, `json: cannot unmarshal JSON string into WrongString.result of Go type string: invalid character '1' looking for beginning of object key string`},
-		{Name(""), `{"result":123}`, `json: cannot unmarshal JSON number into WrongString.result of Go type string`},
-		{Name(""), `{"result":"\""}`, `json: cannot unmarshal JSON string into WrongString.result of Go type string: unexpected end of JSON input`},
-		{Name(""), `{"result":"\"foo"}`, `json: cannot unmarshal JSON string into WrongString.result of Go type string: unexpected end of JSON input`},
+		{Name(""), `{"result":"x"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: invalid character 'x' looking for beginning of object key string`},
+		{Name(""), `{"result":"foo"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: invalid character 'f' looking for beginning of object key string`},
+		{Name(""), `{"result":"123"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: invalid character '1' looking for beginning of object key string`},
+		{Name(""), `{"result":123}`, `json: cannot unmarshal number into Go struct field WrongString.result of type string`},
+		{Name(""), `{"result":"\""}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: unexpected end of JSON input`},
+		{Name(""), `{"result":"\"foo"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: unexpected end of JSON input`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -2543,6 +2567,7 @@ func TestUnmarshalEmbeddedUnexported(t *testing.T) {
 		ptr:      new(S1),
 		out:      &S1{R: 2},
 		err: &UnmarshalTypeError{
+			Value:  "number",
 			Type:   reflect.TypeFor[S1](),
 			Offset: len64(`{"R":2,"Q":`),
 			Struct: "S1",
@@ -2575,6 +2600,7 @@ func TestUnmarshalEmbeddedUnexported(t *testing.T) {
 		ptr:      new(S5),
 		out:      &S5{R: 2},
 		err: &UnmarshalTypeError{
+			Value:  "number",
 			Type:   reflect.TypeFor[S5](),
 			Offset: len64(`{"R":2,"Q":`),
 			Struct: "S5",

--- a/v1/inject.go
+++ b/v1/inject.go
@@ -71,6 +71,9 @@ func transformUnmarshalError(root any, err error) error {
 		if err.Err == jsonv2.ErrUnknownName {
 			return fmt.Errorf("json: unknown field %q", err.JSONPointer.LastToken())
 		}
+		if err.Err == internal.ErrNilInterface {
+			err.Err = nil // non-descriptive for historical reasons
+		}
 
 		// Historically, UnmarshalTypeError has always been inconsistent
 		// about how it reported position information.

--- a/v1/stream.go
+++ b/v1/stream.go
@@ -6,6 +6,7 @@ package json
 
 import (
 	"bytes"
+	"errors"
 	"io"
 
 	jsonv2 "github.com/go-json-experiment/json"
@@ -191,6 +192,16 @@ func (d Delim) String() string {
 func (dec *Decoder) Token() (Token, error) {
 	tok, err := dec.dec.ReadToken()
 	if err != nil {
+		// Historically, v1 would report just [io.EOF] if
+		// the stream is a prefix of a valid JSON value.
+		// It reports an unwrapped [io.ErrUnexpectedEOF] if
+		// truncated within a JSON token such as a literal, number, or string.
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			if len(bytes.Trim(dec.dec.UnreadBuffer(), " \r\n\t,:")) == 0 {
+				return nil, io.EOF
+			}
+			return nil, io.ErrUnexpectedEOF
+		}
 		return nil, transformSyntacticError(err)
 	}
 	switch k := tok.Kind(); k {

--- a/v1/stream_test.go
+++ b/v1/stream_test.go
@@ -500,3 +500,38 @@ func TestHTTPDecoding(t *testing.T) {
 		t.Errorf("Decode error:\n\tgot:  %v\n\twant: io.EOF", err)
 	}
 }
+
+func TestTokenTruncation(t *testing.T) {
+	tests := []struct {
+		in  string
+		err error
+	}{
+		{in: ``, err: io.EOF},
+		{in: `{`, err: io.EOF},
+		{in: `{"`, err: io.ErrUnexpectedEOF},
+		{in: `{"k"`, err: io.EOF},
+		{in: `{"k":`, err: io.EOF},
+		{in: `{"k",`, err: &SyntaxError{"invalid character ',' after object key", int64(len(`{"k"`))}},
+		{in: `{"k"}`, err: &SyntaxError{"invalid character '}' after object key", int64(len(`{"k"`))}},
+		{in: ` [0`, err: io.EOF},
+		{in: `[0.`, err: io.ErrUnexpectedEOF},
+		{in: `[0. `, err: &SyntaxError{"invalid character ' ' in numeric literal", int64(len(`[0.`))}},
+		{in: `[0,`, err: io.EOF},
+		{in: `[0:`, err: &SyntaxError{"invalid character ':' after array element", int64(len(`[0`))}},
+		{in: `n`, err: io.ErrUnexpectedEOF},
+		{in: `nul`, err: io.ErrUnexpectedEOF},
+		{in: `fal `, err: &SyntaxError{"invalid character ' ' in literal false (expecting 's')", int64(len(`fal`))}},
+		{in: `false`, err: io.EOF},
+	}
+	for _, tt := range tests {
+		d := NewDecoder(strings.NewReader(tt.in))
+		for i := 0; true; i++ {
+			if _, err := d.Token(); err != nil {
+				if !reflect.DeepEqual(err, tt.err) {
+					t.Errorf("`%s`: %d.Token error = %#v, want %v", tt.in, i, err, tt.err)
+				}
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pulls in the following changes:
* (https://go.dev/cl/681177) encoding/json/jsontext: preserve buffer capacity in Decoder.Reset
* (https://go.dev/cl/690375) encoding/json/jsontext: preserve buffer capacity in Encoder.Reset
* (https://go.dev/cl/689918) encoding/json: reduce error text regressions under goexperiment.jsonv2
* (https://go.dev/cl/689919) encoding/json: fix extra data regression under goexperiment.jsonv2
* (https://go.dev/cl/689516) encoding/json: fix truncated Token error regression in goexperiment.jsonv2