### PR TITLE
Update to 691af6ca28dad9c72e51346fe10c6aaadc3f940b

### DIFF
--- a/arshal.go
+++ b/arshal.go
@@ -468,7 +468,7 @@ func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct, last bo
 	// was validated before attempting to unmarshal it.
 	if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
 		if err := export.Decoder(in).CheckNextValue(last); err != nil {
-			if err == io.EOF {
+			if err == io.EOF && last {
 				offset := in.InputOffset() + int64(len(in.UnreadBuffer()))
 				return &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
 			}
@@ -485,7 +485,7 @@ func unmarshalDecode(in *jsontext.Decoder, out any, uo *jsonopts.Struct, last bo
 		if !uo.Flags.Get(jsonflags.AllowDuplicateNames) {
 			export.Decoder(in).Tokens.InvalidateDisabledNamespaces()
 		}
-		if err == io.EOF {
+		if err == io.EOF && last {
 			offset := in.InputOffset() + int64(len(in.UnreadBuffer()))
 			return &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
 		}

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -9411,6 +9411,51 @@ func TestUnmarshalDecodeOptions(t *testing.T) {
 	}
 }
 
+func TestUnmarshalDecodeStream(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []any
+		err  error
+	}{
+		{in: ``, err: io.EOF},
+		{in: `{`, err: &jsontext.SyntacticError{ByteOffset: len64(`{`), Err: io.ErrUnexpectedEOF}},
+		{in: `{"`, err: &jsontext.SyntacticError{ByteOffset: len64(`{"`), Err: io.ErrUnexpectedEOF}},
+		{in: `{"k"`, err: &jsontext.SyntacticError{ByteOffset: len64(`{"k"`), JSONPointer: "/k", Err: io.ErrUnexpectedEOF}},
+		{in: `{"k":`, err: &jsontext.SyntacticError{ByteOffset: len64(`{"k":`), JSONPointer: "/k", Err: io.ErrUnexpectedEOF}},
+		{in: `{"k",`, err: &jsontext.SyntacticError{ByteOffset: len64(`{"k"`), JSONPointer: "/k", Err: jsonwire.NewInvalidCharacterError(",", "after object name (expecting ':')")}},
+		{in: `{"k"}`, err: &jsontext.SyntacticError{ByteOffset: len64(`{"k"`), JSONPointer: "/k", Err: jsonwire.NewInvalidCharacterError("}", "after object name (expecting ':')")}},
+		{in: `[`, err: &jsontext.SyntacticError{ByteOffset: len64(`[`), Err: io.ErrUnexpectedEOF}},
+		{in: `[0`, err: &jsontext.SyntacticError{ByteOffset: len64(`[0`), Err: io.ErrUnexpectedEOF}},
+		{in: ` [0`, err: &jsontext.SyntacticError{ByteOffset: len64(` [0`), Err: io.ErrUnexpectedEOF}},
+		{in: `[0.`, err: &jsontext.SyntacticError{ByteOffset: len64(`[`), JSONPointer: "/0", Err: io.ErrUnexpectedEOF}},
+		{in: `[0. `, err: &jsontext.SyntacticError{ByteOffset: len64(`[0.`), JSONPointer: "/0", Err: jsonwire.NewInvalidCharacterError(" ", "in number (expecting digit)")}},
+		{in: `[0,`, err: &jsontext.SyntacticError{ByteOffset: len64(`[0,`), Err: io.ErrUnexpectedEOF}},
+		{in: `[0:`, err: &jsontext.SyntacticError{ByteOffset: len64(`[0`), Err: jsonwire.NewInvalidCharacterError(":", "after array element (expecting ',' or ']')")}},
+		{in: `n`, err: &jsontext.SyntacticError{ByteOffset: len64(`n`), Err: io.ErrUnexpectedEOF}},
+		{in: `nul`, err: &jsontext.SyntacticError{ByteOffset: len64(`nul`), Err: io.ErrUnexpectedEOF}},
+		{in: `fal `, err: &jsontext.SyntacticError{ByteOffset: len64(`fal`), Err: jsonwire.NewInvalidCharacterError(" ", "in literal false (expecting 's')")}},
+		{in: `false`, want: []any{false}, err: io.EOF},
+		{in: `false0.0[]null`, want: []any{false, 0.0, []any{}, nil}, err: io.EOF},
+	}
+	for _, tt := range tests {
+		d := jsontext.NewDecoder(strings.NewReader(tt.in))
+		var got []any
+		for {
+			var v any
+			if err := UnmarshalDecode(d, &v); err != nil {
+				if !reflect.DeepEqual(err, tt.err) {
+					t.Errorf("`%s`: UnmarshalDecode error = %v, want %v", tt.in, err, tt.err)
+				}
+				break
+			}
+			got = append(got, v)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("`%s`: UnmarshalDecode = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
 // BenchmarkUnmarshalDecodeOptions is a minimal decode operation to measure
 // the overhead options setup before the unmarshal operation.
 func BenchmarkUnmarshalDecodeOptions(b *testing.B) {

--- a/v1/indent.go
+++ b/v1/indent.go
@@ -86,17 +86,8 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 }
 
 func appendIndent(dst, src []byte, prefix, indent string) ([]byte, error) {
-	// In v2, trailing whitespace is discarded, while v1 preserved it.
-	dstLen := len(dst)
-	if n := len(src) - len(bytes.TrimRight(src, " \n\r\t")); n > 0 {
-		// Append the trailing whitespace afterwards.
-		defer func() {
-			if len(dst) > dstLen {
-				dst = append(dst, src[len(src)-n:]...)
-			}
-		}()
-	}
 	// In v2, only spaces and tabs are allowed, while v1 allowed any character.
+	dstLen := len(dst)
 	if len(strings.Trim(prefix, " \t"))+len(strings.Trim(indent, " \t")) > 0 {
 		// Use placeholder spaces of correct length, and replace afterwards.
 		invalidPrefix, invalidIndent := prefix, indent
@@ -126,6 +117,11 @@ func appendIndent(dst, src []byte, prefix, indent string) ([]byte, error) {
 		jsontext.WithIndent(indent))
 	if err != nil {
 		return dst[:dstLen], transformSyntacticError(err)
+	}
+
+	// In v2, trailing whitespace is discarded, while v1 preserved it.
+	if n := len(src) - len(bytes.TrimRight(src, " \n\r\t")); n > 0 {
+		dst = append(dst, src[len(src)-n:]...)
 	}
 	return dst, nil
 }

--- a/v1/scanner_test.go
+++ b/v1/scanner_test.go
@@ -72,6 +72,7 @@ func TestCompactAndIndent(t *testing.T) {
 	-5e+2
 ]`},
 		{Name(""), "{\"\":\"<>&\u2028\u2029\"}", "{\n\t\"\": \"<>&\u2028\u2029\"\n}"}, // See golang.org/issue/34070
+		{Name(""), `null`, "null \n\r\t"},                                             // See golang.org/issue/13520 and golang.org/issue/74806
 	}
 	var buf bytes.Buffer
 	for _, tt := range tests {
@@ -100,7 +101,7 @@ func TestCompactAndIndent(t *testing.T) {
 			buf.Reset()
 			if err := Indent(&buf, []byte(tt.compact), "", "\t"); err != nil {
 				t.Errorf("%s: Indent error: %v", tt.Where, err)
-			} else if got := buf.String(); got != tt.indent {
+			} else if got := buf.String(); got != strings.TrimRight(tt.indent, " \n\r\t") {
 				t.Errorf("%s: Compact:\n\tgot:  %s\n\twant: %s", tt.Where, indentNewlines(got), indentNewlines(tt.indent))
 			}
 		})


### PR DESCRIPTION
This pulls in the following changes:
* (https://go.dev/cl/692175) encoding/json/v2: fix UnmarshalDecode regression with EOF
* (https://go.dev/cl/692195) encoding/json: fix Indent trailing whitespace regression in goexperiment.jsonv2