### PR TITLE
Update to 4b1800e47632d52006e3080580e4e60792389759

### DIFF
--- a/arshal_default.go
+++ b/arshal_default.go
@@ -128,7 +128,7 @@ func makeBoolArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 
 		// Optimize for marshaling without preceding whitespace.
@@ -153,7 +153,7 @@ func makeBoolArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		tok, err := dec.ReadToken()
 		if err != nil {
@@ -190,7 +190,7 @@ func makeBoolArshaler(t reflect.Type) *arshaler {
 				return nil
 			}
 		}
-		return newUnmarshalErrorAfterWithSkipping(dec, uo, t, nil)
+		return newUnmarshalErrorAfterWithSkipping(dec, t, nil)
 	}
 	return &fncs
 }
@@ -200,7 +200,7 @@ func makeStringArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 
 		// Optimize for marshaling without preceding whitespace.
@@ -237,7 +237,7 @@ func makeStringArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		var flags jsonwire.ValueFlags
 		val, err := xd.ReadValue(&flags)
@@ -327,7 +327,7 @@ func makeBytesArshaler(t reflect.Type, fncs *arshaler) *arshaler {
 				mo.Format = ""
 				return marshalArray(enc, va, mo)
 			default:
-				return newInvalidFormatError(enc, t, mo)
+				return newInvalidFormatError(enc, t)
 			}
 		} else if mo.Flags.Get(jsonflags.FormatByteArrayAsArray) && va.Kind() == reflect.Array {
 			return marshalArray(enc, va, mo)
@@ -365,7 +365,7 @@ func makeBytesArshaler(t reflect.Type, fncs *arshaler) *arshaler {
 				uo.Format = ""
 				return unmarshalArray(dec, va, uo)
 			default:
-				return newInvalidFormatError(dec, t, uo)
+				return newInvalidFormatError(dec, t)
 			}
 		} else if uo.Flags.Get(jsonflags.FormatByteArrayAsArray) && va.Kind() == reflect.Array {
 			return unmarshalArray(dec, va, uo)
@@ -433,7 +433,7 @@ func makeIntArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 
 		// Optimize for marshaling without preceding whitespace or string escaping.
@@ -454,7 +454,7 @@ func makeIntArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		stringify := xd.Tokens.Last.NeedObjectName() || uo.Flags.Get(jsonflags.StringifyNumbers)
 		var flags jsonwire.ValueFlags
@@ -520,7 +520,7 @@ func makeUintArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 
 		// Optimize for marshaling without preceding whitespace or string escaping.
@@ -541,7 +541,7 @@ func makeUintArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		stringify := xd.Tokens.Last.NeedObjectName() || uo.Flags.Get(jsonflags.StringifyNumbers)
 		var flags jsonwire.ValueFlags
@@ -602,7 +602,7 @@ func makeFloatArshaler(t reflect.Type) *arshaler {
 			if mo.Format == "nonfinite" {
 				allowNonFinite = true
 			} else {
-				return newInvalidFormatError(enc, t, mo)
+				return newInvalidFormatError(enc, t)
 			}
 		}
 
@@ -637,7 +637,7 @@ func makeFloatArshaler(t reflect.Type) *arshaler {
 			if uo.Format == "nonfinite" {
 				allowNonFinite = true
 			} else {
-				return newInvalidFormatError(dec, t, uo)
+				return newInvalidFormatError(dec, t)
 			}
 		}
 		stringify := xd.Tokens.Last.NeedObjectName() || uo.Flags.Get(jsonflags.StringifyNumbers)
@@ -737,7 +737,7 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 				emitNull = false
 				mo.Format = ""
 			default:
-				return newInvalidFormatError(enc, t, mo)
+				return newInvalidFormatError(enc, t)
 			}
 		}
 
@@ -882,7 +882,7 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 			case "emitnull", "emitempty":
 				uo.Format = "" // only relevant for marshaling
 			default:
-				return newInvalidFormatError(dec, t, uo)
+				return newInvalidFormatError(dec, t)
 			}
 		}
 		tok, err := dec.ReadToken()
@@ -992,7 +992,7 @@ func makeMapArshaler(t reflect.Type) *arshaler {
 			}
 			return errUnmarshal
 		}
-		return newUnmarshalErrorAfterWithSkipping(dec, uo, t, nil)
+		return newUnmarshalErrorAfterWithSkipping(dec, t, nil)
 	}
 	return &fncs
 }
@@ -1037,7 +1037,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 		once.Do(init)
 		if errInit != nil && !mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -1199,7 +1199,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		tok, err := dec.ReadToken()
 		if err != nil {
@@ -1317,7 +1317,7 @@ func makeStructArshaler(t reflect.Type) *arshaler {
 			}
 			return errUnmarshal
 		}
-		return newUnmarshalErrorAfterWithSkipping(dec, uo, t, nil)
+		return newUnmarshalErrorAfterWithSkipping(dec, t, nil)
 	}
 	return &fncs
 }
@@ -1414,7 +1414,7 @@ func makeSliceArshaler(t reflect.Type) *arshaler {
 				emitNull = false
 				mo.Format = ""
 			default:
-				return newInvalidFormatError(enc, t, mo)
+				return newInvalidFormatError(enc, t)
 			}
 		}
 
@@ -1462,7 +1462,7 @@ func makeSliceArshaler(t reflect.Type) *arshaler {
 			case "emitnull", "emitempty":
 				uo.Format = "" // only relevant for marshaling
 			default:
-				return newInvalidFormatError(dec, t, uo)
+				return newInvalidFormatError(dec, t)
 			}
 		}
 
@@ -1518,7 +1518,7 @@ func makeSliceArshaler(t reflect.Type) *arshaler {
 			}
 			return errUnmarshal
 		}
-		return newUnmarshalErrorAfterWithSkipping(dec, uo, t, nil)
+		return newUnmarshalErrorAfterWithSkipping(dec, t, nil)
 	}
 	return &fncs
 }
@@ -1539,7 +1539,7 @@ func makeArrayArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 		once.Do(init)
 		if err := enc.WriteToken(jsontext.BeginArray); err != nil {
@@ -1563,7 +1563,7 @@ func makeArrayArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		tok, err := dec.ReadToken()
 		if err != nil {
@@ -1616,7 +1616,7 @@ func makeArrayArshaler(t reflect.Type) *arshaler {
 			}
 			return errUnmarshal
 		}
-		return newUnmarshalErrorAfterWithSkipping(dec, uo, t, nil)
+		return newUnmarshalErrorAfterWithSkipping(dec, t, nil)
 	}
 	return &fncs
 }
@@ -1706,7 +1706,7 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 	fncs.marshal = func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
 		xe := export.Encoder(enc)
 		if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
-			return newInvalidFormatError(enc, t, mo)
+			return newInvalidFormatError(enc, t)
 		}
 		if va.IsNil() {
 			return enc.WriteToken(jsontext.Null)
@@ -1746,7 +1746,7 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 	fncs.unmarshal = func(dec *jsontext.Decoder, va addressableValue, uo *jsonopts.Struct) error {
 		xd := export.Decoder(dec)
 		if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
-			return newInvalidFormatError(dec, t, uo)
+			return newInvalidFormatError(dec, t)
 		}
 		if uo.Flags.Get(jsonflags.MergeWithLegacySemantics) && !va.IsNil() {
 			// Legacy merge behavior is difficult to explain.
@@ -1795,7 +1795,7 @@ func makeInterfaceArshaler(t reflect.Type) *arshaler {
 
 			k := dec.PeekKind()
 			if !isAnyType(t) {
-				return newUnmarshalErrorBeforeWithSkipping(dec, uo, t, internal.ErrNilInterface)
+				return newUnmarshalErrorBeforeWithSkipping(dec, t, internal.ErrNilInterface)
 			}
 			switch k {
 			case 'f', 't':

--- a/arshal_inlined.go
+++ b/arshal_inlined.go
@@ -188,7 +188,7 @@ func unmarshalInlinedFallbackNext(dec *jsontext.Decoder, va addressableValue, uo
 					*b = append(*b, ',')
 				}
 			} else {
-				return newUnmarshalErrorAfterWithSkipping(dec, uo, v.Type(), errRawInlinedNotObject)
+				return newUnmarshalErrorAfterWithSkipping(dec, v.Type(), errRawInlinedNotObject)
 			}
 		}
 		*b = append(*b, quotedName...)

--- a/arshal_test.go
+++ b/arshal_test.go
@@ -3217,6 +3217,11 @@ func TestMarshal(t *testing.T) {
 		in:   struct{ X any }{[8]byte{}},
 		want: `{"X":"called"}`,
 	}, {
+		name:    jsontest.Name("Interfaces/Any/Float/NaN"),
+		in:      struct{ X any }{math.NaN()},
+		want:    `{"X"`,
+		wantErr: EM(fmt.Errorf("unsupported value: %v", math.NaN())).withType(0, reflect.TypeFor[float64]()).withPos(`{"X":`, "/X"),
+	}, {
 		name: jsontest.Name("Interfaces/Any/Maps/Nil"),
 		in:   struct{ X any }{map[string]any(nil)},
 		want: `{"X":{}}`,
@@ -3278,7 +3283,7 @@ func TestMarshal(t *testing.T) {
 			return struct{ X any }{m}
 		}(),
 		want:    `{"X"` + strings.Repeat(`:{""`, startDetectingCyclesAfter),
-		wantErr: EM(internal.ErrCycle).withPos(`{"X":`+strings.Repeat(`{"":`, startDetectingCyclesAfter), "/X"+jsontext.Pointer(strings.Repeat("/", startDetectingCyclesAfter))).withType(0, T[any]()),
+		wantErr: EM(internal.ErrCycle).withPos(`{"X":`+strings.Repeat(`{"":`, startDetectingCyclesAfter), "/X"+jsontext.Pointer(strings.Repeat("/", startDetectingCyclesAfter))).withType(0, T[map[string]any]()),
 	}, {
 		name: jsontest.Name("Interfaces/Any/Slices/Nil"),
 		in:   struct{ X any }{[]any(nil)},

--- a/arshal_time.go
+++ b/arshal_time.go
@@ -48,7 +48,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var m durationArshaler
 			if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
 				if !m.initFormat(mo.Format) {
-					return newInvalidFormatError(enc, t, mo)
+					return newInvalidFormatError(enc, t)
 				}
 			} else if mo.Flags.Get(jsonflags.FormatDurationAsNano) {
 				return marshalNano(enc, va, mo)
@@ -74,13 +74,13 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var u durationArshaler
 			if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
 				if !u.initFormat(uo.Format) {
-					return newInvalidFormatError(dec, t, uo)
+					return newInvalidFormatError(dec, t)
 				}
 			} else if uo.Flags.Get(jsonflags.FormatDurationAsNano) {
 				return unmarshalNano(dec, va, uo)
 			} else {
 				// TODO(https://go.dev/issue/71631): Decide on default duration representation.
-				return newUnmarshalErrorBeforeWithSkipping(dec, uo, t, errors.New("no default representation (see https://go.dev/issue/71631); specify an explicit format"))
+				return newUnmarshalErrorBeforeWithSkipping(dec, t, errors.New("no default representation (see https://go.dev/issue/71631); specify an explicit format"))
 			}
 
 			stringify := !u.isNumeric() || xd.Tokens.Last.NeedObjectName() || uo.Flags.Get(jsonflags.StringifyNumbers)
@@ -125,7 +125,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var m timeArshaler
 			if mo.Format != "" && mo.FormatDepth == xe.Tokens.Depth() {
 				if !m.initFormat(mo.Format) {
-					return newInvalidFormatError(enc, t, mo)
+					return newInvalidFormatError(enc, t)
 				}
 			}
 
@@ -148,7 +148,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			var u timeArshaler
 			if uo.Format != "" && uo.FormatDepth == xd.Tokens.Depth() {
 				if !u.initFormat(uo.Format) {
-					return newInvalidFormatError(dec, t, uo)
+					return newInvalidFormatError(dec, t)
 				}
 			} else if uo.Flags.Get(jsonflags.ParseTimeWithLooseRFC3339) {
 				u.looseRFC3339 = true


### PR DESCRIPTION
This pulls in the following changes:
* (https://go.dev/cl/695278) encoding/json/v2: cleanup error constructors
* (https://go.dev/cl/695276) encoding/json/v2: fix incorrect marshaling of NaN in float64 any
* (https://go.dev/cl/695277) encoding/json/v2: fix wrong type with cyclic marshal error in map[string]any