### PR TITLE
Update to 30686c4cc89e6952ec00846e34016f37d53f31dd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Test
@@ -28,7 +28,7 @@ jobs:
   test-all:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/alias.go
+++ b/alias.go
@@ -724,6 +724,10 @@ func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T) error) *Unmarshalers
 //
 // It is recommended that implementations return a buffer that is safe
 // for the caller to retain and potentially mutate.
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError].
 type Marshaler = json.Marshaler
 
 // MarshalerTo is implemented by types that can marshal themselves.
@@ -735,6 +739,11 @@ type Marshaler = json.Marshaler
 //
 // The implementation must write only one JSON value to the Encoder and
 // must not retain the pointer to [jsontext.Encoder].
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError],
+// unless it is an IO error.
 type MarshalerTo = json.MarshalerTo
 
 // Unmarshaler is implemented by types that can unmarshal themselves.
@@ -748,6 +757,10 @@ type MarshalerTo = json.MarshalerTo
 // unmarshaling into a pre-populated value.
 //
 // Implementations must not retain or mutate the input []byte.
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError].
 type Unmarshaler = json.Unmarshaler
 
 // UnmarshalerFrom is implemented by types that can unmarshal themselves.
@@ -762,6 +775,11 @@ type Unmarshaler = json.Unmarshaler
 // unmarshaling into a pre-populated value.
 //
 // Implementations must not retain the pointer to [jsontext.Decoder].
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError],
+// unless it is a [jsontext.SyntacticError] or an IO error.
 type UnmarshalerFrom = json.UnmarshalerFrom
 
 // ErrUnknownName indicates that a JSON object member could not be
@@ -783,6 +801,11 @@ var ErrUnknownName = json.ErrUnknownName
 
 // SemanticError describes an error determining the meaning
 // of JSON data as Go data or vice-versa.
+//
+// If a [Marshaler], [MarshalerTo], [Unmarshaler], or [UnmarshalerFrom] method
+// returns a SemanticError when called by the [json] package,
+// then the ByteOffset, JSONPointer, and GoType fields are automatically
+// populated by the calling context if they are the zero value.
 //
 // The contents of this error as produced by this package may change over time.
 type SemanticError = json.SemanticError

--- a/arshal_funcs.go
+++ b/arshal_funcs.go
@@ -177,7 +177,8 @@ func MarshalFunc[T any](fn func(T) ([]byte, error)) *Marshalers {
 	typFnc := typedMarshaler{
 		typ: t,
 		fnc: func(enc *jsontext.Encoder, va addressableValue, mo *jsonopts.Struct) error {
-			val, err := fn(va.castTo(t).Interface().(T))
+			v, _ := reflect.TypeAssert[T](va.castTo(t))
+			val, err := fn(v)
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal function of type func(T) ([]byte, error)")
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -222,7 +223,8 @@ func MarshalToFunc[T any](fn func(*jsontext.Encoder, T) error) *Marshalers {
 			xe := export.Encoder(enc)
 			prevDepth, prevLength := xe.Tokens.DepthLength()
 			xe.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := fn(enc, va.castTo(t).Interface().(T))
+			v, _ := reflect.TypeAssert[T](va.castTo(t))
+			err := fn(enc, v)
 			xe.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xe.Tokens.DepthLength()
 			if err == nil && (prevDepth != currDepth || prevLength+1 != currLength) {
@@ -269,7 +271,8 @@ func UnmarshalFunc[T any](fn func([]byte, T) error) *Unmarshalers {
 			if err != nil {
 				return err // must be a syntactic or I/O error
 			}
-			err = fn(val, va.castTo(t).Interface().(T))
+			v, _ := reflect.TypeAssert[T](va.castTo(t))
+			err = fn(val, v)
 			if err != nil {
 				err = wrapSkipFunc(err, "unmarshal function of type func([]byte, T) error")
 				if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -304,7 +307,8 @@ func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T) error) *Unmarshalers
 			xd := export.Decoder(dec)
 			prevDepth, prevLength := xd.Tokens.DepthLength()
 			xd.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := fn(dec, va.castTo(t).Interface().(T))
+			v, _ := reflect.TypeAssert[T](va.castTo(t))
+			err := fn(dec, v)
 			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xd.Tokens.DepthLength()
 			if err == nil && (prevDepth != currDepth || prevLength+1 != currLength) {

--- a/arshal_inlined.go
+++ b/arshal_inlined.go
@@ -50,8 +50,7 @@ func marshalInlinedFallbackAll(enc *jsontext.Encoder, va addressableValue, mo *j
 	}
 
 	if v.Type() == jsontextValueType {
-		// TODO(https://go.dev/issue/62121): Use reflect.Value.AssertTo.
-		b := *v.Addr().Interface().(*jsontext.Value)
+		b, _ := reflect.TypeAssert[jsontext.Value](v.Value)
 		if len(b) == 0 { // TODO: Should this be nil? What if it were all whitespace?
 			return nil
 		}
@@ -174,7 +173,7 @@ func unmarshalInlinedFallbackNext(dec *jsontext.Decoder, va addressableValue, uo
 	v = v.indirect(true)
 
 	if v.Type() == jsontextValueType {
-		b := v.Addr().Interface().(*jsontext.Value)
+		b, _ := reflect.TypeAssert[*jsontext.Value](v.Addr())
 		if len(*b) == 0 { // TODO: Should this be nil? What if it were all whitespace?
 			*b = append(*b, '{')
 		} else {

--- a/arshal_methods.go
+++ b/arshal_methods.go
@@ -41,6 +41,10 @@ var (
 //
 // It is recommended that implementations return a buffer that is safe
 // for the caller to retain and potentially mutate.
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError].
 type Marshaler interface {
 	MarshalJSON() ([]byte, error)
 }
@@ -54,6 +58,11 @@ type Marshaler interface {
 //
 // The implementation must write only one JSON value to the Encoder and
 // must not retain the pointer to [jsontext.Encoder].
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError],
+// unless it is an IO error.
 type MarshalerTo interface {
 	MarshalJSONTo(*jsontext.Encoder) error
 
@@ -72,6 +81,10 @@ type MarshalerTo interface {
 // unmarshaling into a pre-populated value.
 //
 // Implementations must not retain or mutate the input []byte.
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError].
 type Unmarshaler interface {
 	UnmarshalJSON([]byte) error
 }
@@ -88,6 +101,11 @@ type Unmarshaler interface {
 // unmarshaling into a pre-populated value.
 //
 // Implementations must not retain the pointer to [jsontext.Decoder].
+//
+// If the returned error is a [SemanticError], then unpopulated fields
+// of the error may be populated by [json] with additional context.
+// Errors of other types are wrapped within a [SemanticError],
+// unless it is a [jsontext.SyntacticError] or an IO error.
 type UnmarshalerFrom interface {
 	UnmarshalJSONFrom(*jsontext.Decoder) error
 
@@ -111,7 +129,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				(needAddr && va.forcedAddr) {
 				return prevMarshal(enc, va, mo)
 			}
-			marshaler := va.Addr().Interface().(encoding.TextMarshaler)
+			marshaler, _ := reflect.TypeAssert[encoding.TextMarshaler](va.Addr())
 			if err := export.Encoder(enc).AppendRaw('"', false, func(b []byte) ([]byte, error) {
 				b2, err := marshaler.MarshalText()
 				return append(b, b2...), err
@@ -137,7 +155,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				(needAddr && va.forcedAddr) {
 				return prevMarshal(enc, va, mo)
 			}
-			appender := va.Addr().Interface().(encoding.TextAppender)
+			appender, _ := reflect.TypeAssert[encoding.TextAppender](va.Addr())
 			if err := export.Encoder(enc).AppendRaw('"', false, appender.AppendText); err != nil {
 				err = wrapSkipFunc(err, "append method")
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -160,7 +178,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				((needAddr && va.forcedAddr) || export.Encoder(enc).Tokens.Last.NeedObjectName()) {
 				return prevMarshal(enc, va, mo)
 			}
-			marshaler := va.Addr().Interface().(Marshaler)
+			marshaler, _ := reflect.TypeAssert[Marshaler](va.Addr())
 			val, err := marshaler.MarshalJSON()
 			if err != nil {
 				err = wrapSkipFunc(err, "marshal method")
@@ -194,7 +212,8 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			xe := export.Encoder(enc)
 			prevDepth, prevLength := xe.Tokens.DepthLength()
 			xe.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := va.Addr().Interface().(MarshalerTo).MarshalJSONTo(enc)
+			marshaler, _ := reflect.TypeAssert[MarshalerTo](va.Addr())
+			err := marshaler.MarshalJSONTo(enc)
 			xe.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xe.Tokens.DepthLength()
 			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {
@@ -233,7 +252,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				return newUnmarshalErrorAfter(dec, t, errNonStringValue)
 			}
 			s := jsonwire.UnquoteMayCopy(val, flags.IsVerbatim())
-			unmarshaler := va.Addr().Interface().(encoding.TextUnmarshaler)
+			unmarshaler, _ := reflect.TypeAssert[encoding.TextUnmarshaler](va.Addr())
 			if err := unmarshaler.UnmarshalText(s); err != nil {
 				err = wrapSkipFunc(err, "unmarshal method")
 				if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -260,7 +279,7 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			if err != nil {
 				return err // must be a syntactic or I/O error
 			}
-			unmarshaler := va.Addr().Interface().(Unmarshaler)
+			unmarshaler, _ := reflect.TypeAssert[Unmarshaler](va.Addr())
 			if err := unmarshaler.UnmarshalJSON(val); err != nil {
 				err = wrapSkipFunc(err, "unmarshal method")
 				if uo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -284,7 +303,8 @@ func makeMethodArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 			xd := export.Decoder(dec)
 			prevDepth, prevLength := xd.Tokens.DepthLength()
 			xd.Flags.Set(jsonflags.WithinArshalCall | 1)
-			err := va.Addr().Interface().(UnmarshalerFrom).UnmarshalJSONFrom(dec)
+			unmarshaler, _ := reflect.TypeAssert[UnmarshalerFrom](va.Addr())
+			err := unmarshaler.UnmarshalJSONFrom(dec)
 			xd.Flags.Set(jsonflags.WithinArshalCall | 0)
 			currDepth, currLength := xd.Tokens.DepthLength()
 			if (prevDepth != currDepth || prevLength+1 != currLength) && err == nil {

--- a/arshal_time.go
+++ b/arshal_time.go
@@ -57,8 +57,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				return newMarshalErrorBefore(enc, t, errors.New("no default representation (see https://go.dev/issue/71631); specify an explicit format"))
 			}
 
-			// TODO(https://go.dev/issue/62121): Use reflect.Value.AssertTo.
-			m.td = *va.Addr().Interface().(*time.Duration)
+			m.td, _ = reflect.TypeAssert[time.Duration](va.Value)
 			k := stringOrNumberKind(!m.isNumeric() || xe.Tokens.Last.NeedObjectName() || mo.Flags.Get(jsonflags.StringifyNumbers))
 			if err := xe.AppendRaw(k, true, m.appendMarshal); err != nil {
 				if !isSyntacticError(err) && !export.IsIOError(err) {
@@ -85,7 +84,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 
 			stringify := !u.isNumeric() || xd.Tokens.Last.NeedObjectName() || uo.Flags.Get(jsonflags.StringifyNumbers)
 			var flags jsonwire.ValueFlags
-			td := va.Addr().Interface().(*time.Duration)
+			td, _ := reflect.TypeAssert[*time.Duration](va.Addr())
 			val, err := xd.ReadValue(&flags)
 			if err != nil {
 				return err
@@ -129,8 +128,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 				}
 			}
 
-			// TODO(https://go.dev/issue/62121): Use reflect.Value.AssertTo.
-			m.tt = *va.Addr().Interface().(*time.Time)
+			m.tt, _ = reflect.TypeAssert[time.Time](va.Value)
 			k := stringOrNumberKind(!m.isNumeric() || xe.Tokens.Last.NeedObjectName() || mo.Flags.Get(jsonflags.StringifyNumbers))
 			if err := xe.AppendRaw(k, !m.hasCustomFormat(), m.appendMarshal); err != nil {
 				if mo.Flags.Get(jsonflags.ReportErrorsWithLegacySemantics) {
@@ -156,7 +154,7 @@ func makeTimeArshaler(fncs *arshaler, t reflect.Type) *arshaler {
 
 			stringify := !u.isNumeric() || xd.Tokens.Last.NeedObjectName() || uo.Flags.Get(jsonflags.StringifyNumbers)
 			var flags jsonwire.ValueFlags
-			tt := va.Addr().Interface().(*time.Time)
+			tt, _ := reflect.TypeAssert[*time.Time](va.Addr())
 			val, err := xd.ReadValue(&flags)
 			if err != nil {
 				return err

--- a/errors.go
+++ b/errors.go
@@ -62,6 +62,11 @@ func isFatalError(err error, flags jsonflags.Flags) bool {
 // SemanticError describes an error determining the meaning
 // of JSON data as Go data or vice-versa.
 //
+// If a [Marshaler], [MarshalerTo], [Unmarshaler], or [UnmarshalerFrom] method
+// returns a SemanticError when called by the [json] package,
+// then the ByteOffset, JSONPointer, and GoType fields are automatically
+// populated by the calling context if they are the zero value.
+//
 // The contents of this error as produced by this package may change over time.
 type SemanticError struct {
 	requireKeyedLiterals

--- a/example_orderedobject_test.go
+++ b/example_orderedobject_test.go
@@ -53,7 +53,9 @@ func (obj *OrderedObject[V]) MarshalJSONTo(enc *jsontext.Encoder) error {
 // UnmarshalJSONFrom decodes a JSON object from dec into obj.
 func (obj *OrderedObject[V]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if k := dec.PeekKind(); k != '{' {
-		return fmt.Errorf("expected object start, but encountered %v", k)
+		// The [json] package automatically populates relevant fields
+		// in a [json.SemanticError] to provide additional context.
+		return &json.SemanticError{JSONKind: k}
 	}
 	if _, err := dec.ReadToken(); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,4 @@
 // This package will regularly experience breaking changes.
 module github.com/go-json-experiment/json
 
-go 1.24
+go 1.25

--- a/internal/jsonflags/flags.go
+++ b/internal/jsonflags/flags.go
@@ -169,8 +169,8 @@ func (dst *Flags) Join(src Flags) {
 	// Copy over all source presence bits over to the destination (using OR),
 	// then invert the source presence bits to clear out source value (using AND-NOT),
 	// then copy over source value bits over to the destination (using OR).
-	//	e.g., dst := Flags{Presence: 0b_1100_0011, Value: 0b_1000_0011}
-	//	e.g., src := Flags{Presence: 0b_0101_1010, Value: 0b_1001_0010}
+	//	e.g., dst := Flags{Presence: 0b_1100_0011, Values: 0b_1000_0011}
+	//	e.g., src := Flags{Presence: 0b_0101_1010, Values: 0b_1001_0010}
 	dst.Presence |= src.Presence // e.g., 0b_1100_0011 | 0b_0101_1010 -> 0b_110_11011
 	dst.Values &= ^src.Presence  // e.g., 0b_1000_0011 & 0b_1010_0101 -> 0b_100_00001
 	dst.Values |= src.Values     // e.g., 0b_1000_0001 | 0b_1001_0010 -> 0b_100_10011
@@ -182,7 +182,7 @@ func (fs *Flags) Set(f Bools) {
 	// then set the presence for all the identifier bits (using OR),
 	// then invert the identifier bits to clear out the values (using AND-NOT),
 	// then copy over all the identifier bits to the value if LSB is 1.
-	//	e.g., fs := Flags{Presence: 0b_0101_0010, Value: 0b_0001_0010}
+	//	e.g., fs := Flags{Presence: 0b_0101_0010, Values: 0b_0001_0010}
 	//	e.g., f := 0b_1001_0001
 	id := uint64(f) &^ uint64(1)  // e.g., 0b_1001_0001 & 0b_1111_1110 -> 0b_1001_0000
 	fs.Presence |= id             // e.g., 0b_0101_0010 | 0b_1001_0000 -> 0b_1101_0011
@@ -207,7 +207,7 @@ func (fs Flags) Has(f Bools) bool {
 // The value bit of f (i.e., the LSB) is ignored.
 func (fs *Flags) Clear(f Bools) {
 	// Invert f to produce a mask to clear all bits in f (using AND).
-	//	e.g., fs := Flags{Presence: 0b_0101_0010, Value: 0b_0001_0010}
+	//	e.g., fs := Flags{Presence: 0b_0101_0010, Values: 0b_0001_0010}
 	//	e.g., f := 0b_0001_1000
 	mask := uint64(^f)  // e.g., 0b_0001_1000 -> 0b_1110_0111
 	fs.Presence &= mask // e.g., 0b_0101_0010 &  0b_1110_0111 -> 0b_0100_0010


### PR DESCRIPTION
This pulls in the following changes:
* (https://go.dev/cl/701956) encoding/json/v2: document context annotation with SemanticError
* (https://go.dev/cl/701955) encoding/json: use reflect.TypeAssert
* (https://go.dev/cl/701415) encoding/json/internal/jsonflags: fix comment with wrong field name